### PR TITLE
FIS-256: Add flood risk url.

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -19,6 +19,7 @@ const schema = joi.object({
   gaAccId: joi.string().default(''),
   fbAppId: joi.string().default(''),
   siteUrl: joi.string().default(`http://localhost:${defaultPort}`),
+  floodRiskUrl: joi.string().default(`http://localhost:${defaultPort}`),
   sessionPassword: joi.string()
 })
 
@@ -36,6 +37,7 @@ const config = {
   gaAccId: process.env.FLOOD_APP_GA_ID,
   fbAppId: process.env.FLOOD_APP_FBAPP_ID,
   siteUrl: process.env.FLOOD_APP_SITE_URL,
+  floodRiskUrl: process.env.FLOOD_RISK_URL,
   sessionPassword: process.env.FLOOD_APP_SESSION_PASSWORD
 }
 

--- a/server/models/views/location.js
+++ b/server/models/views/location.js
@@ -1,5 +1,6 @@
 const severity = require('../severity')
 const { groupBy } = require('../../util')
+const { floodRiskUrl } = require('../../config')
 
 class ViewModel {
   constructor ({ location, place, floods, stations, impacts }) {
@@ -12,7 +13,8 @@ class ViewModel {
       impacts,
       location: title,
       pageTitle: `${title} flood risk`,
-      metaDescription: `Nearby flood alerts and warnings; latest river and sea levels and flood risk advice for residents living in the ${title} area.`
+      metaDescription: `Nearby flood alerts and warnings; latest river and sea levels and flood risk advice for residents living in the ${title} area.`,
+      floodRiskUrl
     })
 
     const hasFloods = !!floods.length

--- a/server/views/location.html
+++ b/server/views/location.html
@@ -100,7 +100,7 @@
             </a>
           </li>
           <li>
-            <a class="govuk-link" href="#">
+            <a class="govuk-link" href="{{model.floodRiskUrl}}/long-term-flood-risk">
               View long term flood risk information
             </a>
           </li>


### PR DESCRIPTION
FIS-256

https://eaflood.atlassian.net/browse/FIS-256

Part of acceptance criteria for the location summary page is to have a link to the Long Term Flood Risk information page.