### PR TITLE
FIS-592: Fix banner text for multiple warning combinations.

### DIFF
--- a/server/views/station.html
+++ b/server/views/station.html
@@ -26,7 +26,7 @@
         {% if model.alertsBanner %}
         <strong><a class="govuk-link" href="{{ model.alertsLink }}">{{ model.alertsBanner }}</a></strong>
         {% endif %}
-        in this area
+        {{ " in this area" if model.warningAnd or model.severeAnd }}
     </div>
   </div>
 </div>


### PR DESCRIPTION
FIS-592 Station Page - banner does not include "and" when displaying multiple statuses

https://eaflood.atlassian.net/browse/FIS-592

Fix banner text.