### PR TITLE
FIS-610: Fix map link text on target-area page. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8634,9 +8634,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash.get": {
       "version": "4.4.2",

--- a/server/src/js/pages/target-area.js
+++ b/server/src/js/pages/target-area.js
@@ -11,7 +11,7 @@ window.flood.utils.addBrowserBackButton()
 
 // Create LiveMap
 window.flood.maps.createLiveMap('map', {
-  btnText: `View map of flood ${window.flood.model.area.code.slice(4, 5).toLowerCase() === 'w' ? 'warning' : 'alert'} area`,
+  btnText: `View map of the flood ${window.flood.model.area.code.slice(4, 5).toLowerCase() === 'w' ? 'warning' : 'alert'} area`,
   btnClasses: 'defra-button-map govuk-!-margin-bottom-4',
   layers: 'mv,ts,tw,ta',
   targetArea: {


### PR DESCRIPTION
FIS-610: Target Area - Map link no longer including the word "the"

https://eaflood.atlassian.net/browse/FIS-610

Fix map link text on target-area page and update package-lock.json for dependency vulnerability.