### PR TITLE
FIS-673 fix issue with forecast section of water levels graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.2.0",
   "description": "Flood risk app",
   "main": "index.js",
+  "repository": "github:defra/flood-app",
   "engines": {
     "node": ">12"
   },

--- a/server/src/js/components/charts.js
+++ b/server/src/js/components/charts.js
@@ -66,13 +66,15 @@ function LineChart (containerId, data) {
   let observedArea, observed, forecastArea, forecast
   if (hasObserved) {
     chartWrapper.append('g').classed('observed observed-focus', true)
-    observedArea = svg.select('.observed').append('path').datum(lines.filter(l => l.type === 'observed')).classed('observed-area', true)
-    observed = svg.select('.observed').append('path').datum(lines.filter(l => l.type === 'observed')).classed('observed-line', true)
+    const observedLine = lines.filter(l => l.type === 'observed')
+    observedArea = svg.select('.observed').append('path').datum(observedLine).classed('observed-area', true)
+    observed = svg.select('.observed').append('path').datum(observedLine).classed('observed-line', true)
   }
   if (hasForecast) {
     chartWrapper.append('g').classed('forecast', true)
-    forecastArea = svg.select('.forecast').append('path').datum(lines.filter(l => l.type === 'forecast')).classed('forecast-area', true)
-    forecast = svg.select('.forecast').append('path').datum(lines.filter(l => l.type === 'forecast')).classed('forecast-line', true)
+    const forecastLine = lines.filter(l => l.type === 'forecast')
+    forecastArea = svg.select('.forecast').append('path').datum(forecastLine).classed('forecast-area', true)
+    forecast = svg.select('.forecast').append('path').datum(forecastLine).classed('forecast-line', true)
   }
 
   // Add timeline

--- a/server/src/js/components/charts.js
+++ b/server/src/js/components/charts.js
@@ -25,12 +25,12 @@ function LineChart (containerId, data) {
     const errorFilter = l => !l.err
     const errorAndNegativeFilter = l => errorFilter(l) && l._ >= 0
     const filterFunction = data.plotNegativeValues ? errorFilter : errorAndNegativeFilter
-    lines = data.observed.filter(filterFunction).reverse()
+    lines = data.observed.filter(filterFunction).map(l => ({ ...l, type: 'observed' })).reverse()
     dataPoint = lines[0] ? JSON.parse(JSON.stringify(lines[0])) : null
     hasObserved = true
   }
   if (data.forecast.length) {
-    lines = lines.concat(data.forecast)
+    lines = lines.concat(data.forecast.map(l => ({ ...l, type: 'forecast' })))
     hasForecast = true
   }
 
@@ -66,13 +66,13 @@ function LineChart (containerId, data) {
   let observedArea, observed, forecastArea, forecast
   if (hasObserved) {
     chartWrapper.append('g').classed('observed observed-focus', true)
-    observedArea = svg.select('.observed').append('path').datum(lines).classed('observed-area', true)
-    observed = svg.select('.observed').append('path').datum(lines).classed('observed-line', true)
+    observedArea = svg.select('.observed').append('path').datum(lines.filter(l => l.type === 'observed')).classed('observed-area', true)
+    observed = svg.select('.observed').append('path').datum(lines.filter(l => l.type === 'observed')).classed('observed-line', true)
   }
   if (hasForecast) {
     chartWrapper.append('g').classed('forecast', true)
-    forecastArea = svg.select('.forecast').append('path').datum(data.forecast).classed('forecast-area', true)
-    forecast = svg.select('.forecast').append('path').datum(data.forecast).classed('forecast-line', true)
+    forecastArea = svg.select('.forecast').append('path').datum(lines.filter(l => l.type === 'forecast')).classed('forecast-area', true)
+    forecast = svg.select('.forecast').append('path').datum(lines.filter(l => l.type === 'forecast')).classed('forecast-line', true)
   }
 
   // Add timeline

--- a/server/src/js/components/charts.js
+++ b/server/src/js/components/charts.js
@@ -26,7 +26,7 @@ function LineChart (containerId, data) {
     const errorAndNegativeFilter = l => errorFilter(l) && l._ >= 0
     const filterFunction = data.plotNegativeValues ? errorFilter : errorAndNegativeFilter
     lines = data.observed.filter(filterFunction).map(l => ({ ...l, type: 'observed' })).reverse()
-    dataPoint = lines[0] ? JSON.parse(JSON.stringify(lines[0])) : null
+    dataPoint = lines[lines.length - 1] ? JSON.parse(JSON.stringify(lines[lines.length - 1])) : null
     hasObserved = true
   }
   if (data.forecast.length) {


### PR DESCRIPTION
Forecast section was being overwritten by observed section so solid line and shaded area was extending into the forecast section.

An example (at the time of writing) would be https://lfw-dev.aws.defra.cloud/station/8208