### PR TITLE
unit test fix for clocks going back

### DIFF
--- a/test/routes/station.js
+++ b/test/routes/station.js
@@ -1218,8 +1218,8 @@ lab.experiment('Test - /station/{id}', () => {
     const fakeStationForecastData = () => data.fakeStationForecastDataMax
     const fakeWarningsAlertsData = () => []
 
-    fakeStationForecastData().SetofValues[0].Value[0].$.date = moment.tz('Europe/London').format('YYYY-MM-DD')
-    fakeStationForecastData().SetofValues[0].Value[0].$.time = moment.tz('Europe/London').format('H:m:s')
+    fakeStationForecastData().SetofValues[0].Value[0].$.date = moment().utc().add(1, 'hours').format('YYYY-MM-DD')
+    fakeStationForecastData().SetofValues[0].Value[0].$.time = moment().utc().add(1, 'hours').format('HH:mm:ss')
 
     sandbox.stub(floodService, 'getStationById').callsFake(fakeStationData)
     sandbox.stub(floodService, 'getStationTelemetry').callsFake(fakeTelemetryData)


### PR DESCRIPTION
For context:

> forecast data fudge set the datetime of the forecast to now but Europe/London timezone, but technically that is now so not a future forecast. However as forecast timeseries data is in UTC when we were BST it seemed to code that the fudged value was an hour in the future
> clocks go back and Europe/London is now UTC, therefore that datetime is definitely "now" so not in the future
> fix is to set date to now (utc) + 1 hour