### PR TITLE
FIS-673 RLOI graph not scaled for forecast values

### DIFF
--- a/server/src/js/components/charts.js
+++ b/server/src/js/components/charts.js
@@ -252,9 +252,11 @@ function LineChart (containerId, data) {
   }
 
   function modifyAxis () {
-    // Initialize scales
-    xExtent = d3.extent(data.observed, function (d, i) { return new Date(d.ts) })
-    yExtent = d3.extent(data.observed, function (d, i) { return data.plotNegativeValues ? d._ : Math.max(d._, 0) })
+    // Note: xExtent uses observed and forecast data rather than lines for the scenario where river levels
+    // start or end as -ve since we still need to determine the datetime span of the graph even if the
+    // values are excluded from plotting by virtue of being -ve
+    xExtent = d3.extent(data.observed.concat(data.forecast), function (d, i) { return new Date(d.ts) })
+    yExtent = d3.extent(lines, function (d, i) { return data.plotNegativeValues ? d._ : Math.max(d._, 0) })
 
     // Increase X range by 5% from now value
     let date = new Date(data.now)

--- a/server/src/js/components/charts.js
+++ b/server/src/js/components/charts.js
@@ -256,7 +256,7 @@ function LineChart (containerId, data) {
     // start or end as -ve since we still need to determine the datetime span of the graph even if the
     // values are excluded from plotting by virtue of being -ve
     xExtent = d3.extent(data.observed.concat(data.forecast), function (d, i) { return new Date(d.ts) })
-    yExtent = d3.extent(lines, function (d, i) { return data.plotNegativeValues ? d._ : Math.max(d._, 0) })
+    yExtent = d3.extent(lines, function (d, i) { return d._ })
 
     // Increase X range by 5% from now value
     let date = new Date(data.now)


### PR DESCRIPTION
Fix for x axis for river levels not including forecast values in the extent
 
Scenarios checked:

- River levels (9351)
- River levels with forecast (7333)
- River levels with negative values (8302)
- Coastal station (8382)
- Groundwater station (3317)

Would be good to have a scenario with a mix of +ve and -ve values as well as forecast data but that will take me a bit longer to find. 
