### PR TITLE
FSR-77: Create 10km buffer to bbox for station location search

### DIFF
--- a/server/models/views/alerts-and-warnings.js
+++ b/server/models/views/alerts-and-warnings.js
@@ -8,7 +8,7 @@ class ViewModel {
       station: station || null,
       metaNoIndex: true,
       placeName: place ? place.name : '',
-      placeBbox: place ? place.bbox : [],
+      placeBbox: place ? place.bbox2k : [],
       placeCentre: place ? place.center : [],
       timestamp: Date.now(),
       error: error ? true : null,

--- a/server/models/views/location.js
+++ b/server/models/views/location.js
@@ -10,7 +10,7 @@ class ViewModel {
     Object.assign(this, {
       q: location,
       place,
-      placeBbox: place ? place.bbox : [],
+      placeBbox: place ? place.bbox2k : [],
       floods,
       impacts,
       location: title,

--- a/server/models/views/river-and-sea-levels.js
+++ b/server/models/views/river-and-sea-levels.js
@@ -129,7 +129,7 @@ class ViewModel {
 
     this.export = {
       countLevels: this.countLevels,
-      placeBbox: place ? place.bbox : stationsBbox,
+      placeBbox: place ? place.bbox10k : stationsBbox,
       bingMaps: bingKeyMaps
     }
   }

--- a/server/routes/alerts-and-warnings.js
+++ b/server/routes/alerts-and-warnings.js
@@ -48,7 +48,7 @@ module.exports = [{
         return h.view('alerts-and-warnings', { model })
       } else {
         // Data passed to floods model so the schema is the same as cached floods
-        const data = await floodService.getFloodsWithin(place.bbox)
+        const data = await floodService.getFloodsWithin(place.bbox2k)
         floods = new Floods(data)
         model = new ViewModel({ location, place, floods, station })
         return h.view('alerts-and-warnings', { model })

--- a/server/routes/location.js
+++ b/server/routes/location.js
@@ -34,9 +34,9 @@ module.exports = {
       { floods },
       stations
     ] = await Promise.all([
-      floodService.getImpactsWithin(place.bbox),
-      floodService.getFloodsWithin(place.bbox),
-      floodService.getStationsWithin(place.bbox)
+      floodService.getImpactsWithin(place.bbox2k),
+      floodService.getFloodsWithin(place.bbox2k),
+      floodService.getStationsWithin(place.bbox10k)
     ])
     const model = new ViewModel({ location, place, floods, stations, impacts })
     return h.view('location', { model })

--- a/server/routes/river-and-sea-levels.js
+++ b/server/routes/river-and-sea-levels.js
@@ -52,7 +52,7 @@ module.exports = [{
         return h.view('river-and-sea-levels', { model })
       } else {
         // Finally show place filtered station list
-        stations = await floodService.getStationsWithin(place.bbox)
+        stations = await floodService.getStationsWithin(place.bbox10k)
         model = new ViewModel({ location, place, stations })
         model.referer = request.headers.referer
         return h.view('river-and-sea-levels', { model })

--- a/server/services/location.js
+++ b/server/services/location.js
@@ -81,13 +81,16 @@ async function find (location) {
 
   const isEngland = await floodServices.getIsEngland(center[0], center[1])
 
-  // add on 2000m buffer to place.bbox for search
-  bbox = addBufferToBbox(bbox, 2000)
+  // add on 2000m buffer to place.bbox for warnings and alerts search
+  const bbox2k = addBufferToBbox(bbox, 2000)
+  // add on 10000m buffer to place.bbox for stations search
+  const bbox10k = addBufferToBbox(bbox, 10000)
 
   return {
     name,
     center,
-    bbox,
+    bbox2k,
+    bbox10k,
     address,
     isEngland,
     isUK,

--- a/test/services/location.js
+++ b/test/services/location.js
@@ -102,7 +102,9 @@ lab.experiment('location service test', () => {
     Code.expect(result.Error).to.be.undefined()
     Code.expect(result.address).to.equal('United Kingdom')
     // Test that bounding box for location has been given 2km buffer
-    Code.expect(result.bbox).to.equal(JSON.parse('[-18.297640835711686,49.94624559508356,12.557641064593524,60.79096093998717]'))
+    Code.expect(result.bbox2k).to.equal(JSON.parse('[-18.297640835711686,49.94624559508356,12.557641064593524,60.79096093998717]'))
+    // Test that bounding box for location has been given 10km buffer
+    Code.expect(result.bbox10k).to.equal(JSON.parse('[-18.36950605844125,49.89997768952511,12.629506287323087,60.82601178696]'))
   })
 
   lab.test('Check for Bing call returning low confidence and hence no results', async () => {


### PR DESCRIPTION
FSR-77: Station location search query

https://eaflood.atlassian.net/browse/FSR-77

In order to return results from a station location query on the rivers-and-sea-levels list page that match the live service, increase the bbox buffer to 10Km.