### PR TITLE
FSR-297-296 Displaying of threshold data (#204)

### DIFF
--- a/server/models/views/station.js
+++ b/server/models/views/station.js
@@ -241,11 +241,6 @@ class ViewModel {
     // Set Lat long
     const coordinates = JSON.parse(this.station.coordinates).coordinates
     coordinates.reverse()
-    /*
-    this.lat = coordinates[0]
-    this.long = coordinates[1]
-    this.warningsUrl = `/warnings?stationid=${this.id}`
-    */
 
     // Set pageTitle, metaDescription and metaKeywords
     let stationType
@@ -276,9 +271,7 @@ class ViewModel {
         id: 'latest',
         value: this.station.recentValue._.toFixed(2),
         description: 'Latest level',
-        shortname: '',
-        type: 'latest',
-        isExceeded: false
+        shortname: ''
       })
     }
     if (this.station.porMaxValue) {
@@ -288,75 +281,35 @@ class ViewModel {
         description: this.station.thresholdPorMaxDate
           ? 'Water reaches the highest level recorded at this measuring station (recorded on ' + this.station.thresholdPorMaxDate + ')'
           : 'Water reaches the highest level recorded at this measuring station',
-        shortname: 'Highest level on record',
-        type: '',
-        isExceeded: this.station.recentValue && !this.station.recentValue.err
-          ? this.station.recentValue._ >= this.station.porMaxValue
-          : false
+        shortname: 'Highest level on record'
       })
     }
-    // if ffoi and has alerts use them
-    if (this.ffoi && this.ffoi.warnings.FALThreshold.length) {
-      this.ffoi.warnings.FALThreshold.forEach(threshold => {
-        thresholds.push({
-          id: threshold.fwis_code,
-          value: threshold.value.toFixed(2),
-          description: `This is the top of the normal range, above this a flood alert may be issued for <a href="/target-area/${threshold.fwis_code}">${threshold.fwa_name}</a>`,
-          shortname: 'Top of normal range',
-          type: threshold.fwa_severity === 3
-            ? 'alert'
-            : 'target-area',
-          isNormal: true,
-          isExceeded: this.station.recentValue && !this.station.recentValue.err ? this.station.recentValue._ >= threshold.value : false
-        })
+
+    if (this.alertThreshold) {
+      thresholds.push({
+        id: 'alertThreshold',
+        value: this.alertThreshold,
+        description: 'Low lying land flooding is possible above this level. One or more flood alerts may be issued',
+        shortname: 'Possible flood alerts'
       })
-      // otherwise check if it has a percentile5
-    } else if (this.station.percentile5) {
+    }
+
+    if (this.warningThreshold) {
+      thresholds.push({
+        id: 'warningThreshold',
+        value: this.warningThreshold,
+        description: 'Property flooding is possible above this level. One or more flood warnings may be issued',
+        shortname: 'Possible flood warnings'
+      })
+    }
+
+    if (this.station.percentile5) {
       // Only push typical range if it has a percentil5
       thresholds.push({
         id: 'pc5',
         value: this.station.percentile5,
-        description: 'This is the top of the normal range, above this flooding to low lying land is possible',
-        shortname: 'Top of normal range',
-        type: '',
-        isNormal: true,
-        isExceeded: this.station.recentValue && !this.station.recentValue.err ? this.station.recentValue._ >= this.station.percentile5 : false
-      })
-    }
-    // if ffoi and has warnings use them
-    if (this.ffoi && this.ffoi.warnings.FWThreshold.length) {
-      this.ffoi.warnings.FWThreshold.forEach(threshold => {
-        let type = 'target-area'
-        switch (threshold.fwa_severity) {
-          case 1:
-            type = 'severe'
-            break
-          case 2:
-            type = 'warning'
-            break
-          case 4:
-            type = 'removed'
-            break
-        }
-        thresholds.push({
-          id: threshold.fwis_code,
-          value: threshold.value.toFixed(2),
-          description: `A flood warning may be issued for <a href="/target-area/${threshold.fwis_code}">${threshold.fwa_name}</a>`,
-          shortname: 'Flood warning may be issued',
-          type: type,
-          isExceeded: this.station.recentValue && !this.station.recentValue.err ? this.station.recentValue._ >= threshold.value : false
-        })
-      })
-      // otherwise check if it has a warningThreshold
-    } else if (this.warningThreshold) {
-      // Only push if it has warningThreshold
-      thresholds.push({
-        id: 'warning',
-        value: this.warningThreshold,
-        description: 'A flood warning may be issued',
-        shortname: 'Flood warning may be issued',
-        type: '',
-        isExceeded: this.station.recentValue && !this.station.recentValue.err ? this.station.recentValue._ >= this.station.warningThreshold : false
+        description: 'This is the top of the normal range.',
+        shortname: 'Top of normal range'
       })
     }
 
@@ -366,15 +319,13 @@ class ViewModel {
     }
 
     if (impacts) {
-      const station = this.station
       impacts.forEach(function (impact) {
         thresholds.push({
           id: impact.impactid,
           value: Number(impact.value).toFixed(2),
-          description: impact.description,
+          description: `Historical event: ${impact.description}`,
           shortname: impact.shortname,
-          type: '',
-          isExceeded: station.recentValue && !station.recentValue.err && station.recentValue._ >= impact.value
+          type: 'historical'
         })
       })
     }
@@ -393,7 +344,10 @@ class ViewModel {
     thresholds = Object.keys(thresholds).map(key => {
       return {
         level: key,
-        values: thresholds[key]
+        values: thresholds[key],
+        isLatest: thresholds[key][0].id === 'latest',
+        type: thresholds[key][0].type || '',
+        isExceeded: this.station.recentValue && !this.station.recentValue.err && this.station.recentValue._ >= key
       }
     })
     thresholds = thresholds.sort((a, b) => b.level - a.level)
@@ -402,15 +356,6 @@ class ViewModel {
     // Set remaining station properties
     this.isUpstream = this.station.direction === 'upstream'
     this.isDownstream = this.station.direction === 'downstream'
-    /*
-    this.centroidJSON = JSON.stringify(coordinates)
-    this.stationJSON = JSON.stringify(this.station)
-    this.forecast = this.ffoi || {}
-    this.forecastJSON = this.ffoi ? this.ffoi.forecastJSON : JSON.stringify({})
-    */
-
-    // Page category for feedback categorisation
-    // this.pageCategory = this.isFfoi ? 'station-ffoi' : ''
 
     // Set canonical url
     this.metaCanonical = `/station/${this.station.id}${this.station.direction === 'upstream' ? '' : '/downstream'}`

--- a/server/src/js/components/toggle-list-display.js
+++ b/server/src/js/components/toggle-list-display.js
@@ -1,0 +1,43 @@
+'use strict'
+// Toggle list display component
+
+const { forEach } = window.flood.utils
+
+const ToggleListDisplay = (container, options) => {
+  let isExpanded = false
+  const list = document.querySelector('.defra-flood-impact-list')
+  const items = list.querySelectorAll(`[data-toggle-list-display-item="${options.type}"]`)
+  const button = document.createElement('button')
+  button.className = 'defra-button-text govuk-!-margin-bottom-2'
+  button.setAttribute('aria-controls', list.id)
+  container.appendChild(button)
+
+  const toggleDisplay = () => {
+    // Toggle Button
+    button.innerText = `${isExpanded ? 'Hide' : 'Show'} ${options.btnText}`
+    button.setAttribute('aria-expanded', isExpanded)
+    // Toggle list
+    forEach(items, (item) => {
+      item.style.display = isExpanded ? 'block' : 'none'
+    })
+  }
+
+  //
+  // Initialise
+  //
+
+  toggleDisplay()
+
+  //
+  // Events
+  //
+
+  button.addEventListener('click', (e) => {
+    isExpanded = !isExpanded
+    toggleDisplay()
+  })
+}
+
+window.flood.createToggleListDisplay = (container, options) => {
+  return ToggleListDisplay(container, options)
+}

--- a/server/src/js/pages/station.js
+++ b/server/src/js/pages/station.js
@@ -7,6 +7,7 @@ import '../components/map/styles'
 import '../components/map/layers'
 import '../components/map/container'
 import '../components/map/live'
+import '../components/toggle-list-display'
 // Add browser back button
 window.flood.utils.addBrowserBackButton()
 // Create LiveMap
@@ -75,5 +76,14 @@ if (chart) {
     if (action) {
       action.appendChild(button)
     }
+  })
+}
+
+// Add toggle list display for imapacts
+const toggleListDisplay = document.getElementById('toggle-list-display')
+if (toggleListDisplay) {
+  window.flood.createToggleListDisplay(toggleListDisplay, {
+    type: 'impact',
+    btnText: 'historical events'
   })
 }

--- a/server/src/sass/application.scss
+++ b/server/src/sass/application.scss
@@ -57,6 +57,7 @@ $govuk-breakpoints: (
 @import "components/context-footer";
 @import "components/feedback";
 @import "components/top-link";
+@import "components/toggle-list-display";
 
 // Utilities
 @import "utilities/details";

--- a/server/src/sass/components/_toggle-list-display.scss
+++ b/server/src/sass/components/_toggle-list-display.scss
@@ -1,0 +1,3 @@
+.js-enabled [data-toggle-list-display-item] {
+    display: none;
+}

--- a/server/views/station.html
+++ b/server/views/station.html
@@ -211,30 +211,26 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h2 class="govuk-heading-m govuk-!-margin-top-6">How levels here could affect nearby areas</h2>
+    {% if model.station.hasImpacts %}
+    <span id="toggle-list-display" data-toggle-list-display-type="impact"></span>
+    {% endif %}
     <dl class="defra-flood-impact-list govuk-!-margin-bottom-0">
       {% for band in model.thresholds %}
-      {% for threshold in band.values %} 
-      <div class="defra-flood-impact-list__row {% if threshold.type == 'latest' %} defra-flood-impact-list__row--current {% elif threshold.isExceeded === true %} defra-flood-impact-list__row--exceeded{% endif %}">
+      <div class="defra-flood-impact-list__row {% if band.isLatest %} defra-flood-impact-list__row--current {% elif band.isExceeded %} defra-flood-impact-list__row--exceeded{% endif %}" {% if band.type === 'historical' %} data-toggle-list-display-item="impact" {% endif %}>
         <dt class="defra-flood-impact-list__key">
-          {{ threshold.value }}m
+          {{ band.level }}m
         </dt>
-        <dd class="defra-flood-impact-list__value" data-id="{{ threshold.id }}" data-level="{{ threshold.value }}" data-name="{{ threshold.shortname }}" data-normal="{% if threshold.isNormal %}true{% else %}false{% endif %}">
+        {% for threshold in band.values %} 
+        <dd class="defra-flood-impact-list__value"  {% if threshold.type === 'historical' %} data-toggle-list-display-item="impact" {% endif %} data-id="{{ threshold.id }}" data-level="{{ threshold.value }}" data-name="{{ threshold.shortname }}" data-normal="{% if threshold.isNormal %}true{% else %}false{% endif %}">
           <div class="defra-flood-impact-list__container">
             {{ threshold.description | safe }}
             {% if threshold.type != 'latest' %}
             <span class="defra-flood-impact-list__action"></span>
             {% endif %}
           </div>
-          {% if threshold.type === 'alert' %}
-          <span class="defra-flood-impact-list__alert" title="Flood alert has been issued">!</span>
-          {% elif threshold.type === 'warning' %}
-          <span class="defra-flood-impact-list__warning" title="Flood warning has been issued">!</span>
-          {% elif threshold.type === 'severe' %}
-          <span class="defra-flood-impact-list__severe" title="Severe flood warning has been issued">!</span>
-          {% endif %}
         </dd>
+        {% endfor %}
       </div>
-      {% endfor %}
       {% endfor %}
     </dl> 
   </div>

--- a/test/models/station.js
+++ b/test/models/station.js
@@ -110,6 +110,7 @@ lab.experiment('Station model test', () => {
     Code.expect(Result.station.id).to.equal(9302)
     Code.expect(Result.station.river).to.equal('Groundwater Level')
     Code.expect(Result.station.hasPercentiles).to.equal(true)
+    Code.expect(Result.station.hasImpacts).to.equal(false)
   })
   lab.test('Test station viewModel plotNegativeValues should be true for groundwater station', async () => {
     const viewModel = new ViewModel(data.stationGroudwater)

--- a/test/routes/station.js
+++ b/test/routes/station.js
@@ -1006,7 +1006,6 @@ lab.experiment('Test - /station/{id}', () => {
     const response = await server.inject(options)
 
     Code.expect(response.statusCode).to.equal(200)
-    Code.expect(response.payload).to.contain('<a href="/target-area/062FWF46Hertford">River Lee at Hertford and Ware</a>')
     Code.expect(response.payload).to.not.contain('The highest level in the forecast is')
     Code.expect(response.payload).to.contain('Past impacts might not happen at the same level if flood defences have been put in place since then.')
   })
@@ -1255,7 +1254,6 @@ lab.experiment('Test - /station/{id}', () => {
     const response = await server.inject(options)
 
     Code.expect(response.statusCode).to.equal(200)
-    Code.expect(response.payload).to.contain('<a href="/target-area/062FWF46Hertford">River Lee at Hertford and Ware</a>')
     Code.expect(response.payload).to.contain('The highest level in our forecast is')
     Code.expect(response.payload).to.contain('<a href="/station/7332" class="defra-flood-nav__link defra-flood-nav__link--upstream">Go upstream</a>')
     Code.expect(response.payload).to.contain('<a href="/station/7357" class="defra-flood-nav__link defra-flood-nav__link--downstream">Go downstream</a>')


### PR DESCRIPTION
* FSR-297: Toggle display of impacts on station page. Refactor display of alerts/warnings.

* FSR-297: Remove commented out code.

* remove html for icons in impacts

* FSR-297: Hide disply link if no impacts. Add test condition.

Co-authored-by: John Shields <John.Shields@environment-agency.gov.uk>
Co-authored-by: nikiwycherley <niki.wycherley@environment-agency.gov.uk>