### PR TITLE
fix/FSR-428: Fix broken aria on cookies page.

### DIFF
--- a/server/src/js/core.js
+++ b/server/src/js/core.js
@@ -130,7 +130,7 @@ const saveButton = document.getElementById('cookies-save')
 if (saveButton) {
   saveButton.addEventListener('click', function (e) {
     e.preventDefault()
-    const useCookies = document.querySelectorAll('input[name="sign-in"]')
+    const useCookies = document.querySelectorAll('input[name="accept-analytics"]')
     window.flood.utils.setCookie('seen_cookie_message', 'true', 30)
     if (useCookies[0].checked) {
       window.flood.utils.setCookie('set_cookie_usage', 'true', 30)

--- a/server/views/cookies.html
+++ b/server/views/cookies.html
@@ -114,14 +114,14 @@
             </legend>
             <div class="govuk-radios govuk-radios--inline">
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="sign-in" name="sign-in" type="radio" value="government-gateway" aria-describedby="sign-in-item-hint" {{ "checked" if analyticsCookiesSet }}>
-                <label class="govuk-label govuk-radios__label" for="sign-in">
+                <input class="govuk-radios__input" id="accept-analytics-yes" name="accept-analytics" type="radio" {{ "checked" if analyticsCookiesSet }}>
+                <label class="govuk-label govuk-radios__label" for="accept-analytics-yes">
                   Yes
                 </label>
               </div>
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="sign-in-2" name="sign-in" type="radio" value="govuk-verify" aria-describedby="sign-in-2-item-hint" {{ "checked" if not analyticsCookiesSet }}>
-                <label class="govuk-label govuk-radios__label" for="sign-in-2">
+                <input class="govuk-radios__input" id="accept-analytics-no" name="accept-analytics" type="radio" {{ "checked" if not analyticsCookiesSet }}>
+                <label class="govuk-label govuk-radios__label" for="accept-analytics-no">
                   No
                 </label>
               </div>


### PR DESCRIPTION
FSR-428: Fix broken aria on cookies page.

https://eaflood.atlassian.net/browse/FSR-428

WAVE Tool highlighted two Broken ARIA on Cookies Page. As the ARIA target reference is missing a screen reader will not pick up the inputs.