### PR TITLE
Use autocomplete default - feature/FSR-468

### DIFF
--- a/server/models/views/find-location.js
+++ b/server/models/views/find-location.js
@@ -29,7 +29,8 @@ class ViewModel {
       id: 'location',
       name: 'location',
       attributes: {
-        maxlength: 200
+        maxlength: 200,
+        spellcheck: 'false'
       },
       classes: 'govuk-!-width-one-half'
     }

--- a/server/views/alerts-and-warnings.html
+++ b/server/views/alerts-and-warnings.html
@@ -39,7 +39,7 @@
           <div class="govuk-form-group">
             <label class="govuk-label" for="location">Search a location</label>
               <div class="defra-search">
-                <input class="defra-search__input" id="location" name="location" type="search" value="{{ model.q }}">
+                <input class="defra-search__input" id="location" name="location" type="search" spellcheck="false" value="{{ model.q }}">
                 <div class="defra-search__submit-container">
                   <button class="defra-search__button">Search</button>
               </div>

--- a/server/views/river-and-sea-levels.html
+++ b/server/views/river-and-sea-levels.html
@@ -51,7 +51,7 @@
         <div class="govuk-form-group">
           <label class="govuk-label" for="location">Search a location</label>
             <div class="defra-search">
-              <input class="defra-search__input" id="location" name="q" type="search" value="{{ model.q }}">
+              <input class="defra-search__input" id="location" name="q" type="search" spellcheck="false" value="{{ model.q }}">
               <div class="defra-search__submit-container">
                 <button class="defra-search__button">Search</button>
               </div>


### PR DESCRIPTION
Default autocomplete on location search 

https://eaflood.atlassian.net/browse/FSR-468

Remove the following attributes on location search so default behaviour is reinstated:

- autocomplete
- autocorrect
- auto capitalize
- spellcheck