### PR TITLE
FSR-483: Fix black bar appearing below map on IOS15/Safari.

### DIFF
--- a/server/src/js/components/map/container.js
+++ b/server/src/js/components/map/container.js
@@ -38,6 +38,7 @@ window.flood.maps.MapContainer = function MapContainer (mapId, options) {
   // Disable body scrolling and hide non-map elements
   document.title = options.title
   document.body.classList.add('defra-map-body')
+  document.documentElement.classList.add('defra-map-html')
 
   // Create the map container element
   const containerElement = document.createElement('div')
@@ -256,6 +257,7 @@ window.flood.maps.MapContainer = function MapContainer (mapId, options) {
       document.title = options.originalTitle
       // Unlock body scroll
       document.body.classList.remove('defra-map-body')
+      document.documentElement.classList.remove('defra-map-html')
       clearAllBodyScrollLocks()
       // Remove map and return focus
       containerElement.parentNode.removeChild(containerElement)
@@ -436,9 +438,11 @@ window.flood.maps.MapContainer = function MapContainer (mapId, options) {
 
   // Mouse or touch interaction
   containerElement.addEventListener('pointerdown', (e) => {
-    infoElement.blur()
-    keyElement.blur()
     viewport.removeAttribute('keyboard-focus')
+    // Address OpenLayers performance bug when viewport has focus?
+    if (document.activeElement === viewport) {
+      exitMapButtonElement.focus()
+    }
   })
 
   // Disable pinch and double tap zoom

--- a/server/src/sass/components/map/_map.scss
+++ b/server/src/sass/components/map/_map.scss
@@ -32,6 +32,9 @@
     @include defra-visually-hidden;
   }
 }
+.defra-map-html {
+  height: 100vh;
+}
 .defra-map-body {
   position: fixed;
   overflow: hidden;
@@ -39,6 +42,9 @@
   right:0px;
   bottom:0px;
   left:0px;
+}
+.defra-map-visibility-hidden {
+  visibility: hidden;
 }
 .defra-map-viewport {
   -webkit-touch-callout: none;


### PR DESCRIPTION
Black bar appearing below map on iOS15/Safari

https://eaflood.atlassian.net/browse/FSR-483

Fix situation for  iOS 15/Safari combination where a black bar is being displayed where the search bar was. Resolution it to ensure map resizes to cover space.