### PR TITLE
Release 5.10.0 version update and release notes.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flood-app",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "flood-app",
-      "version": "5.9.0",
+      "version": "5.10.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flood-app",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "description": "Flood risk app",
   "main": "index.js",
   "repository": "github:defra/flood-app",

--- a/release-docs/CFF-5.10.0.txt
+++ b/release-docs/CFF-5.10.0.txt
@@ -1,0 +1,28 @@
+# Check for flooding 5.10.0 Wednesday 22nd June 2022
+
+# Release
+
+5.10.0
+
+https://eaflood.atlassian.net/projects/FSR/versions/15908/tab/release-report-all-issues
+
+# Tickets
+
+# Bug
+
+FSR-579 Rainfall totals not corresponding to values in the rainfall graphs
+
+# Task
+
+FSR-585 Changes to FGS API
+
+# Instructions
+
+Straight forward application build for release
+
+LFW_{stage}_04_UPDATE_FLOOD_APP_AND_SERVICE_PIPELINE
+
+Execute smoke tests and forward results
+
+Thanks.
+


### PR DESCRIPTION
Release 5.10.0 version update and release notes.

https://eaflood.atlassian.net/projects/FSR/versions/15908/tab/release-report-all-issues

Tickets included in this release:

FSR-579 Rainfall totals not corresponding to values in the rainfall graphs
FSR-585 Changes to FGS API