### PR TITLE
Release 5.11.0 version update and release notes.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flood-app",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "flood-app",
-      "version": "5.10.0",
+      "version": "5.11.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flood-app",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "description": "Flood risk app",
   "main": "index.js",
   "repository": "github:defra/flood-app",

--- a/release-docs/CFF-5.11.0.txt
+++ b/release-docs/CFF-5.11.0.txt
@@ -1,0 +1,24 @@
+# Check for flooding 5.11.0 Wednesday 29th June 2022
+
+# Release
+
+5.11.0
+
+https://eaflood.atlassian.net/projects/FSR/versions/16032/tab/release-report-all-issues
+
+# Tickets
+
+# Task
+
+FSR-599 Update link to NRW site for Welsh stations
+
+# Instructions
+
+Straight forward application build for release
+
+LFW_{stage}_04_UPDATE_FLOOD_APP_AND_SERVICE_PIPELINE
+
+Execute smoke tests and forward results
+
+Thanks.
+


### PR DESCRIPTION
Release 5.11.0 version update and release notes.

https://eaflood.atlassian.net/projects/FSR/versions/16032/tab/release-report-all-issues

Tickets included in this release:

FSR-599 Update link to NRW site for Welsh stations