### PR TITLE
FSR-620 - Display of FGS text should honour new lines (CSS approach)

### DIFF
--- a/server/models/outlook.js
+++ b/server/models/outlook.js
@@ -45,7 +45,8 @@ class Outlook {
       }
     })
 
-    this._full = outlook.public_forecast.england_forecast
+    // multiple new lines should be treated as one
+    this._full = outlook.public_forecast.england_forecast.replace(/\n+/g, '\n')
 
     const issueDate = new Date(outlook.issued_at)
 

--- a/server/src/sass/components/_flood-meta.scss
+++ b/server/src/sass/components/_flood-meta.scss
@@ -7,4 +7,7 @@
         padding-top:15px;
         border-top:1px solid $govuk-border-colour;
     }
+    &--p {
+      white-space: pre-line;
+    }
 }

--- a/server/views/national.html
+++ b/server/views/national.html
@@ -70,7 +70,7 @@
         <p class="govuk-body govuk-!-margin-bottom-0">There is no recent data.</p>
       </div>
     {% else %}
-      <p class="govuk-body">
+      <p class="defra-flood-meta--p govuk-body">
         {{ model.outlook.full }}
       </p>
       {% if model.outlook.hasOutlookConcern %}

--- a/test/models/outlook.js
+++ b/test/models/outlook.js
@@ -139,10 +139,10 @@ lab.experiment('Outlook model test', () => {
 
     Code.expect(Result).to.be.equal(riskLevelsOutput)
   })
-  lab.test('Check outlook full', async () => {
+  lab.test('Check outlook full (multiple new lines should be reduced to one)', async () => {
     const Result = await outlook.full
 
-    const fullOutput = 'Local flooding from surface water and rivers is possible but not expected in places across much of the north of England on Friday due to widespread rain and heavy showers. Local flooding from rivers is possible, and flooding from surface water possible but not expected, across Wales and much of central and southern England on Friday.\nFurther local flooding from surface water and rivers is possible but not expected on Saturday and Sunday in parts of northern England due to heavy, thundery showers.\nLocal minor river and surface water flooding impacts are possible but not expected in parts of the north of England on Monday.\n\nProperties may flood and there may be travel disruption.'
+    const fullOutput = 'Local flooding from surface water and rivers is possible but not expected in places across much of the north of England on Friday due to widespread rain and heavy showers. Local flooding from rivers is possible, and flooding from surface water possible but not expected, across Wales and much of central and southern England on Friday.\nFurther local flooding from surface water and rivers is possible but not expected on Saturday and Sunday in parts of northern England due to heavy, thundery showers.\nLocal minor river and surface water flooding impacts are possible but not expected in parts of the north of England on Monday.\nProperties may flood and there may be travel disruption.'
 
     Code.expect(Result).to.be.equal(fullOutput)
   })


### PR DESCRIPTION
This is the approach suggested by the Met Office using just CSS.

Works fine but has limited control on line spacing.

Preferred approach is [here](https://github.com/DEFRA/flood-app/pull/330)