### PR TITLE
Refactor name formatting

### DIFF
--- a/server/util.js
+++ b/server/util.js
@@ -109,7 +109,7 @@ function rainfallTelemetryPadOut (values, valueDuration) {
   return values
 }
 
-function formatName (name = '', addressLine) {
+function formatName (name = '', addressLine = undefined) {
   // Note: We assume Bing is consitent in it's capitalisation of terms so we don't lower case them
   // (i.e. 'Durham, durham' will not occur in the real world)
 
@@ -119,7 +119,7 @@ function formatName (name = '', addressLine) {
     .filter(part => !(addressLine && part === addressLine))
   // remove repeated words
     .filter((part, index, allParts) => part !== allParts[index + 1])
-    .filter((part) => part !== 'United Kingdom')
+    .filter(part => part !== 'United Kingdom')
     .join(', ')
 }
 

--- a/server/util.js
+++ b/server/util.js
@@ -109,6 +109,20 @@ function rainfallTelemetryPadOut (values, valueDuration) {
   return values
 }
 
+function formatName (name = '', addressLine) {
+  // Note: We assume Bing is consitent in it's capitalisation of terms so we don't lower case them
+  // (i.e. 'Durham, durham' will not occur in the real world)
+
+  return name
+    .split(/,\s*/)
+  // Strip out addressLine to make name returned more ambiguous as we're not giving property specific information
+    .filter(part => !(addressLine && part === addressLine))
+  // remove repeated words
+    .filter((part, index, allParts) => part !== allParts[index + 1])
+    .filter((part) => part !== 'United Kingdom')
+    .join(', ')
+}
+
 module.exports = {
   get,
   post,
@@ -121,6 +135,7 @@ module.exports = {
   cleanseLocation,
   addBufferToBbox,
   formatValue,
+  formatName,
   toMarked,
   dateDiff,
   formatRainfallTelemetry,

--- a/test/server/util.js
+++ b/test/server/util.js
@@ -1,0 +1,30 @@
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+const lab = exports.lab = Lab.script()
+const { formatName } = require('../../server/util')
+
+lab.experiment('formatName', () => {
+  lab.test('Repeating parts are removed', async () => {
+    Code.expect(formatName('Durham, Durham')).to.equal('Durham')
+  })
+  lab.test('Similar parts are not removed', async () => {
+    Code.expect(formatName('Durham, County Durham')).to.equal('Durham, County Durham')
+  })
+  lab.test('United Kingdom removed', async () => {
+    Code.expect(formatName('Durham, United Kingdom')).to.equal('Durham')
+  })
+  lab.test('Address part removed', async () => {
+    Code.expect(formatName('The Big House, Durham', 'The Big House')).to.equal('Durham')
+  })
+  lab.test('Duplicate but not repeating parts are not removed', async () => {
+    // Note: not sure of an example which would occur in the real world example but included here for completeness
+    Code.expect(formatName('Newcastle, Northumberland, Newcastle')).to.equal('Newcastle, Northumberland, Newcastle')
+  })
+  lab.test('Case mismatch is not considered duplicate', async () => {
+    // Note: not expected to occur in the real world, see comments in formatName
+    Code.expect(formatName('Durham, durham')).to.equal('Durham, durham')
+  })
+  lab.test('Fails gracefully with undefined name', async () => {
+    Code.expect(formatName()).to.equal('')
+  })
+})

--- a/test/services/location.js
+++ b/test/services/location.js
@@ -880,5 +880,73 @@ lab.experiment('location service test', () => {
       Code.expect(result.name).to.equal('Surrey')
       Code.expect(result.address).to.equal('Surrey')
     })
+    lab.test('Should remove location name from address', async () => {
+      const util = require('../../server/util')
+
+      const fakeLocationData = () => {
+        return {
+          authenticationResultCode: 'ValidCredentials',
+          brandLogoUri: 'http://dev.virtualearth.net/Branding/logo_powered_by.png',
+          copyright: 'Copyright © 2022 Microsoft and its suppliers. All rights reserved. This API cannot be accessed and the content and any results may not be used, reproduced or transmitted in any manner without express written permission from Microsoft Corporation.',
+          resourceSets: [
+            {
+              estimatedTotal: 1,
+              resources: [
+                {
+                  __type: 'Location:http://schemas.microsoft.com/search/local/ws/rest/v1',
+                  bbox: [
+                    50.927121183043326,
+                    -1.4106113633013098,
+                    50.93484661818468,
+                    -1.39426923563231
+                  ],
+                  name: 'Richard Taunton Place, Southampton Test, Southampton, SO17 1',
+                  point: { type: 'Point', coordinates: [50.9309839, -1.4024403] },
+                  address: {
+                    addressLine: 'Richard Taunton Place',
+                    adminDistrict: 'England',
+                    adminDistrict2: 'Southampton',
+                    countryRegion: 'United Kingdom',
+                    formattedAddress: 'Richard Taunton Place, Southampton Test, Southampton, SO17 1',
+                    locality: 'Southampton',
+                    postalCode: 'SO17 1',
+                    countryRegionIso2: 'GB'
+                  },
+                  confidence: 'Medium',
+                  entityType: 'RoadBlock',
+                  geocodePoints: [
+                    {
+                      type: 'Point',
+                      coordinates: [50.9309839, -1.4024403],
+                      calculationMethod: 'Interpolation',
+                      usageTypes: ['Display']
+                    }
+                  ],
+                  matchCodes: ['UpHierarchy']
+                }
+              ]
+            }
+          ],
+          statusCode: 200,
+          statusDescription: 'OK',
+          traceId: 'c29dd05c394b483eb55bd92fee1c2275|DU00002749|0.0.0.1|Ref A: BB7F66F3C3214CACA66A7614B0393AD1 Ref B: DB3EDGE2121 Ref C: 2022-10-18T10:19:08Z'
+        }
+      }
+
+      sandbox.stub(util, 'getJson').callsFake(fakeLocationData)
+      sandbox.stub(floodService, 'getIsEngland').callsFake(isEngland)
+
+      const location = require('../../server/services/location')
+
+      const result = await location.find('').then((resolvedValue) => {
+        return resolvedValue
+      }, (error) => {
+        return error
+      })
+
+      Code.expect(result).to.be.a.object()
+      Code.expect(result.Error).to.be.undefined()
+      Code.expect(result.name).to.equal('Southampton Test, Southampton, SO17 1')
+    })
   })
 })


### PR DESCRIPTION
* Move name formatting to utility function
* Changed from imperative to declarative form
* Added tests for clarity and to document intent

Note: These changes have reduced the SonarCloud Cognitive Complexity measure of `server/services/location.js` to 14 from 21