### PR TITLE
Fix disambiguation loop for Kent

### DIFF
--- a/server/routes/river-and-sea-levels.js
+++ b/server/routes/river-and-sea-levels.js
@@ -14,6 +14,7 @@ module.exports = [{
     const taCode = request.query['target-area']
     const rloiid = request.query['rloi-id']
     const rainfallid = request.query['rainfall-id']
+    const includeTypes = (request.query.includeTypes ?? 'place,river').split(',')
     const riverid = request.query.riverId
     const queryType = request.query.searchType
     const queryGroup = request.query.group
@@ -33,7 +34,9 @@ module.exports = [{
         console.error(`Location search error: [${error.name}] [${error.message}]`)
         console.error(error)
       }
-      rivers = await request.server.methods.flood.getRiverByName(location)
+      if (includeTypes.includes('river')) {
+        rivers = await request.server.methods.flood.getRiverByName(location)
+      }
     }
 
     if (locationError && rivers.length === 0) {
@@ -64,6 +67,7 @@ module.exports = [{
         q: joi.string().trim().max(200),
         group: joi.string().trim().max(11),
         searchType: joi.string().trim().max(11),
+        includeTypes: joi.string(),
         'rloi-id': joi.string(),
         'rainfall-id': joi.string(),
         'target-area': joi.string(),

--- a/server/routes/river-and-sea-levels.js
+++ b/server/routes/river-and-sea-levels.js
@@ -6,18 +6,6 @@ const locationService = require('../services/location')
 const util = require('../util')
 const route = 'river-and-sea-levels'
 
-async function findPlace (location) {
-  let place
-  try {
-    place = await locationService.find(util.cleanseLocation(location))
-    place = notinUk(place) ? undefined : place
-  } catch (error) {
-    console.error(`Location search error: [${error.name}] [${error.message}]`)
-    console.error(error)
-  }
-  return place
-}
-
 module.exports = [{
   method: 'GET',
   path: `/${route}`,
@@ -129,4 +117,17 @@ const getStations = async (request, place, rloiid, originalStation, rainfallid, 
     return request.server.methods.flood.getStationsWithin(place.bbox10k)
   }
 }
+
 const notinUk = place => !place.isUK || place.isScotlandOrNorthernIreland
+
+async function findPlace (location) {
+  let place
+  try {
+    place = await locationService.find(util.cleanseLocation(location))
+    place = notinUk(place) ? undefined : place
+  } catch (error) {
+    console.error(`Location search error: [${error.name}] [${error.message}]`)
+    console.error(error)
+  }
+  return place
+}

--- a/server/routes/river-and-sea-levels.js
+++ b/server/routes/river-and-sea-levels.js
@@ -34,9 +34,10 @@ module.exports = [{
     let rivers = []
     let place, stations, originalStation, model
 
-    // if we have a location query then get the place
     if (location && !location.match(/^england$/i)) {
-      place = await findPlace(util.cleanseLocation(location))
+      if (includeTypes.includes('place')) {
+        place = await findPlace(util.cleanseLocation(location))
+      }
       if (includeTypes.includes('river')) {
         rivers = await request.server.methods.flood.getRiverByName(location)
       }

--- a/server/views/river-and-sea-levels.html
+++ b/server/views/river-and-sea-levels.html
@@ -87,7 +87,7 @@
     {% endif %}
     {% if model.stations.length %}
 		<ul class="govuk-list">
-			<li><a href="/river-and-sea-levels?q={{model.placeAddress}}">{{ model.placeAddress | toMarked(model.q) | safe }}</a></li>
+			<li><a href="/river-and-sea-levels?q={{model.placeAddress}}&includeTypes=place">{{ model.placeAddress | toMarked(model.q) | safe }}</a></li>
 		</ul>
 		{% endif %}
 		<p>Alternatively try searching again</p>

--- a/test/routes/river-and-sea-levels.js
+++ b/test/routes/river-and-sea-levels.js
@@ -1648,4 +1648,130 @@ lab.experiment('Test - /river-and-sea-levels', () => {
     Code.expect(response.payload).to.match(/River Alne at[\s\n]+Henley River/)
     Code.expect(response.statusCode).to.equal(200)
   })
+  lab.test('GET /river-and-sea-levels?q=avon&includeTypes=river returns only the rivers', async () => {
+    const floodService = require('../../server/services/flood')
+    const fakeStationsData = () => [{
+      river_id: 'river-alne',
+      river_name: 'River Alne',
+      navigable: true,
+      view_rank: 1,
+      rank: '1',
+      rloi_id: 2083,
+      up: null,
+      down: 2048,
+      telemetry_id: '2621',
+      region: 'Midlands',
+      catchment: 'Warwickshire Avon',
+      wiski_river_name: 'River Alne',
+      agency_name: 'Henley River',
+      external_name: 'Henley River',
+      station_type: 'S',
+      status: 'Active',
+      qualifier: 'u',
+      iswales: false,
+      value: '0.414',
+      value_timestamp: '2022-09-26T13:30:00.000Z',
+      value_erred: false,
+      percentile_5: '0.546',
+      percentile_95: '0.387',
+      centroid: '0101000020E6100000068A4FA62670FCBF9C9AE66602264A40',
+      lon: -1.77738060917966,
+      lat: 52.29694830188711,
+      day_total: null,
+      six_hr_total: null,
+      one_hr_total: null,
+      id: '610'
+    }]
+    const fakeIsEngland = () => {
+      return { is_england: true }
+    }
+    const fakeRiversData = () => [
+      {
+        local_name: 'Little Avon River',
+        qualified_name: 'Little Avon River',
+        other_names: null,
+        river_id: 'little-avon-river'
+      },
+      {
+        local_name: 'River Avon',
+        qualified_name: 'River Avon (Bristol)',
+        other_names: null,
+        river_id: 'river-avon-bristol'
+      },
+      {
+        local_name: 'River Avon',
+        qualified_name: 'River Avon (Corsham)',
+        other_names: null,
+        river_id: 'river-avon-corsham'
+      },
+      {
+        local_name: 'River Avon',
+        qualified_name: 'River Avon (Devon)',
+        other_names: null,
+        river_id: 'river-avon-devon'
+      },
+      {
+        local_name: 'River Avon',
+        qualified_name: 'River Avon (Hampshire)',
+        other_names: null,
+        river_id: 'river-avon-hampshire'
+      },
+      {
+        local_name: 'River Avon',
+        qualified_name: 'River Avon (Warwickshire)',
+        other_names: null,
+        river_id: 'river-avon-warwickshire'
+      },
+      {
+        local_name: 'Sherston Avon',
+        qualified_name: 'Sherston Avon',
+        other_names: null,
+        river_id: 'sherston-avon'
+      },
+      {
+        local_name: 'Tetbury Avon',
+        qualified_name: 'Tetbury Avon',
+        other_names: null,
+        river_id: 'tetbury-avon'
+      }
+    ]
+
+    const fakeGetJson = () => data.avonGetJson
+
+    sandbox.stub(floodService, 'getStationsWithin').callsFake(fakeStationsData)
+    sandbox.stub(floodService, 'getRiverByName').callsFake(fakeRiversData)
+    sandbox.stub(floodService, 'getIsEngland').callsFake(fakeIsEngland)
+
+    const riversPlugin = {
+      plugin: {
+        name: 'rivers',
+        register: (server, options) => {
+          server.route(require('../../server/routes/river-and-sea-levels'))
+        }
+      }
+    }
+
+    const util = require('../../server/util')
+    sandbox.stub(util, 'getJson').callsFake(fakeGetJson)
+
+    await server.register(require('../../server/plugins/views'))
+    await server.register(require('../../server/plugins/session'))
+    await server.register(riversPlugin)
+    // Add Cache methods to server
+    const registerServerMethods = require('../../server/services/server-methods')
+    registerServerMethods(server)
+
+    await server.initialize()
+    const options = {
+      method: 'GET',
+      url: '/river-and-sea-levels?q=avon&includeTypes=river'
+    }
+
+    const response = await server.inject(options)
+
+    Code.expect(response.payload).to.not.contain('Levels near')
+    Code.expect(response.payload).to.contain('Tetbury <mark>Avon</mark>')
+    Code.expect(response.payload).to.contain('More than one match was found for your location.')
+    Code.expect(response.statusCode).to.equal(200)
+  })
 })

--- a/test/routes/river-and-sea-levels.js
+++ b/test/routes/river-and-sea-levels.js
@@ -1524,4 +1524,128 @@ lab.experiment('Test - /river-and-sea-levels', () => {
     Code.expect(response.payload).to.contain('More than one match was found for your location.')
     Code.expect(response.statusCode).to.equal(200)
   })
+  lab.test('GET /river-and-sea-levels?q=avon&includeTypes=place returns only the place', async () => {
+    const floodService = require('../../server/services/flood')
+    const fakeStationsData = () => [{
+      river_id: 'river-alne',
+      river_name: 'River Alne',
+      navigable: true,
+      view_rank: 1,
+      rank: '1',
+      rloi_id: 2083,
+      up: null,
+      down: 2048,
+      telemetry_id: '2621',
+      region: 'Midlands',
+      catchment: 'Warwickshire Avon',
+      wiski_river_name: 'River Alne',
+      agency_name: 'Henley River',
+      external_name: 'Henley River',
+      station_type: 'S',
+      status: 'Active',
+      qualifier: 'u',
+      iswales: false,
+      value: '0.414',
+      value_timestamp: '2022-09-26T13:30:00.000Z',
+      value_erred: false,
+      percentile_5: '0.546',
+      percentile_95: '0.387',
+      centroid: '0101000020E6100000068A4FA62670FCBF9C9AE66602264A40',
+      lon: -1.77738060917966,
+      lat: 52.29694830188711,
+      day_total: null,
+      six_hr_total: null,
+      one_hr_total: null,
+      id: '610'
+    }]
+    const fakeIsEngland = () => {
+      return { is_england: true }
+    }
+    const fakeRiversData = () => [
+      {
+        local_name: 'Little Avon River',
+        qualified_name: 'Little Avon River',
+        other_names: null,
+        river_id: 'little-avon-river'
+      },
+      {
+        local_name: 'River Avon',
+        qualified_name: 'River Avon (Bristol)',
+        other_names: null,
+        river_id: 'river-avon-bristol'
+      },
+      {
+        local_name: 'River Avon',
+        qualified_name: 'River Avon (Corsham)',
+        other_names: null,
+        river_id: 'river-avon-corsham'
+      },
+      {
+        local_name: 'River Avon',
+        qualified_name: 'River Avon (Devon)',
+        other_names: null,
+        river_id: 'river-avon-devon'
+      },
+      {
+        local_name: 'River Avon',
+        qualified_name: 'River Avon (Hampshire)',
+        other_names: null,
+        river_id: 'river-avon-hampshire'
+      },
+      {
+        local_name: 'River Avon',
+        qualified_name: 'River Avon (Warwickshire)',
+        other_names: null,
+        river_id: 'river-avon-warwickshire'
+      },
+      {
+        local_name: 'Sherston Avon',
+        qualified_name: 'Sherston Avon',
+        other_names: null,
+        river_id: 'sherston-avon'
+      },
+      {
+        local_name: 'Tetbury Avon',
+        qualified_name: 'Tetbury Avon',
+        other_names: null,
+        river_id: 'tetbury-avon'
+      }
+    ]
+
+    const fakeGetJson = () => data.avonGetJson
+
+    sandbox.stub(floodService, 'getStationsWithin').callsFake(fakeStationsData)
+    sandbox.stub(floodService, 'getRiverByName').callsFake(fakeRiversData)
+    sandbox.stub(floodService, 'getIsEngland').callsFake(fakeIsEngland)
+
+    const riversPlugin = {
+      plugin: {
+        name: 'rivers',
+        register: (server, options) => {
+          server.route(require('../../server/routes/river-and-sea-levels'))
+        }
+      }
+    }
+
+    const util = require('../../server/util')
+    sandbox.stub(util, 'getJson').callsFake(fakeGetJson)
+
+    await server.register(require('../../server/plugins/views'))
+    await server.register(require('../../server/plugins/session'))
+    await server.register(riversPlugin)
+    // Add Cache methods to server
+    const registerServerMethods = require('../../server/services/server-methods')
+    registerServerMethods(server)
+
+    await server.initialize()
+    const options = {
+      method: 'GET',
+      url: '/river-and-sea-levels?q=avon&includeTypes=place'
+    }
+
+    const response = await server.inject(options)
+
+    Code.expect(response.payload).to.match(/River Alne at[\s\n]+Henley River/)
+    Code.expect(response.statusCode).to.equal(200)
+  })
 })


### PR DESCRIPTION
Note: This problem only happens when the name returned by Bing is the same as the localised name which is also the same as a river. Kent is the only example so far.

This is a stop gap fix until disambiguation is addressed properly and a decision is made on whether we stick with Bing or move to the OS places data set. 