### PR TITLE
Fix: sanitise query term passed to river search

### DIFF
--- a/server/routes/river-and-sea-levels.js
+++ b/server/routes/river-and-sea-levels.js
@@ -160,11 +160,12 @@ async function locationQueryHandler (request, h) {
   let rivers = []
   let places = []
   if (location && !location.match(/^england$/i)) {
+    const cleanLocation = util.cleanseLocation(location)
     if (includeTypes.includes('place')) {
-      places = await findPlaces(util.cleanseLocation(location))
+      places = await findPlaces(cleanLocation)
     }
     if (includeTypes.includes('river')) {
-      rivers = await request.server.methods.flood.getRiverByName(location)
+      rivers = await request.server.methods.flood.getRiverByName(cleanLocation)
     }
   }
 

--- a/server/routes/river-and-sea-levels.js
+++ b/server/routes/river-and-sea-levels.js
@@ -165,7 +165,7 @@ async function locationQueryHandler (request, h) {
       places = await findPlaces(cleanLocation)
     }
     if (includeTypes.includes('river')) {
-      rivers = await request.server.methods.flood.getRiverByName(cleanLocation)
+      rivers = await request.server.methods.flood.getRiversByName(cleanLocation)
     }
   }
 

--- a/server/services/flood.js
+++ b/server/services/flood.js
@@ -133,7 +133,7 @@ module.exports = {
     return util.getJson(`${serviceUrl}/target-area/${taCode}`)
   },
 
-  getRiverByName (location) {
+  getRiversByName (location) {
     return util.getJson(`${serviceUrl}/river-name/${location}`)
   },
 

--- a/server/services/server-methods.js
+++ b/server/services/server-methods.js
@@ -58,7 +58,7 @@ module.exports = server => {
     }
   })
 
-  server.method('flood.getRiverByName', floodServices.getRiverByName, {
+  server.method('flood.getRiversByName', floodServices.getRiversByName, {
     cache: {
       cache: cacheType,
       expiresIn: 1 * 60 * 1000, // 1 minute

--- a/test/routes/river-and-sea-levels.js
+++ b/test/routes/river-and-sea-levels.js
@@ -46,7 +46,7 @@ lab.experiment('Test - /river-and-sea-levels', () => {
     sandbox.stub(util, 'getJson').callsFake(fakeGetJson)
     const fakeRiversData = () => []
 
-    sandbox.stub(floodService, 'getRiverByName').callsFake(fakeRiversData)
+    sandbox.stub(floodService, 'getRiversByName').callsFake(fakeRiversData)
 
     const riversPlugin = {
       plugin: {
@@ -93,7 +93,7 @@ lab.experiment('Test - /river-and-sea-levels', () => {
 
     const fakeRiversData = () => []
 
-    sandbox.stub(floodService, 'getRiverByName').callsFake(fakeRiversData)
+    sandbox.stub(floodService, 'getRiversByName').callsFake(fakeRiversData)
 
     const riversPlugin = {
       plugin: {
@@ -131,7 +131,7 @@ lab.experiment('Test - /river-and-sea-levels', () => {
 
     const fakeRiversData = () => []
 
-    sandbox.stub(floodService, 'getRiverByName').callsFake(fakeRiversData)
+    sandbox.stub(floodService, 'getRiversByName').callsFake(fakeRiversData)
 
     const fakeGetJson = () => {
       throw new Error('Bing error')
@@ -184,7 +184,7 @@ lab.experiment('Test - /river-and-sea-levels', () => {
 
     const fakeRiversData = () => []
 
-    sandbox.stub(floodService, 'getRiverByName').callsFake(fakeRiversData)
+    sandbox.stub(floodService, 'getRiversByName').callsFake(fakeRiversData)
 
     const fakeGetJson = () => {
       return {
@@ -666,7 +666,7 @@ lab.experiment('Test - /river-and-sea-levels', () => {
 
     const fakeRiversData = () => []
 
-    sandbox.stub(floodService, 'getRiverByName').callsFake(fakeRiversData)
+    sandbox.stub(floodService, 'getRiversByName').callsFake(fakeRiversData)
     sandbox.stub(floodService, 'getIsEngland').callsFake(fakeIsEngland)
     sandbox.stub(floodService, 'getStationsWithin').callsFake(fakeStationsData)
 
@@ -1570,7 +1570,7 @@ lab.experiment('Test - /river-and-sea-levels', () => {
     ]
 
     sandbox.stub(floodService, 'getStations').callsFake(fakeStationsData)
-    sandbox.stub(floodService, 'getRiverByName').callsFake(fakeRiversData)
+    sandbox.stub(floodService, 'getRiversByName').callsFake(fakeRiversData)
     sandbox.stub(floodService, 'getIsEngland').callsFake(fakeIsEngland)
 
     const fakeGetJson = () => {
@@ -1717,7 +1717,7 @@ lab.experiment('Test - /river-and-sea-levels', () => {
     const fakeGetJson = () => data.avonGetJson
 
     sandbox.stub(floodService, 'getStationsWithin').callsFake(fakeStationsData)
-    sandbox.stub(floodService, 'getRiverByName').callsFake(fakeRiversData)
+    sandbox.stub(floodService, 'getRiversByName').callsFake(fakeRiversData)
     sandbox.stub(floodService, 'getIsEngland').callsFake(fakeIsEngland)
 
     const riversPlugin = {
@@ -1842,7 +1842,7 @@ lab.experiment('Test - /river-and-sea-levels', () => {
     const fakeGetJson = () => data.avonGetJson
 
     sandbox.stub(floodService, 'getStationsWithin').callsFake(fakeStationsData)
-    sandbox.stub(floodService, 'getRiverByName').callsFake(fakeRiversData)
+    sandbox.stub(floodService, 'getRiversByName').callsFake(fakeRiversData)
     sandbox.stub(floodService, 'getIsEngland').callsFake(fakeIsEngland)
 
     const riversPlugin = {
@@ -1958,7 +1958,7 @@ lab.experiment('Test - /river-and-sea-levels', () => {
     const fakeGetJson = () => data.avonGetJson
 
     sandbox.stub(floodService, 'getStationsWithin').callsFake(fakeStationsData)
-    sandbox.stub(floodService, 'getRiverByName').callsFake(fakeRiversData)
+    sandbox.stub(floodService, 'getRiversByName').callsFake(fakeRiversData)
     sandbox.stub(floodService, 'getIsEngland').callsFake(fakeIsEngland)
 
     const riversPlugin = {
@@ -2063,7 +2063,7 @@ lab.experiment('Test - /river-and-sea-levels', () => {
     }
 
     sandbox.stub(floodService, 'getStationsWithin').callsFake(fakeStationsData)
-    sandbox.stub(floodService, 'getRiverByName').callsFake(fakeRiversData)
+    sandbox.stub(floodService, 'getRiversByName').callsFake(fakeRiversData)
     sandbox.stub(floodService, 'getIsEngland').callsFake(fakeIsEngland)
 
     const riversPlugin = {

--- a/test/services/flood.js
+++ b/test/services/flood.js
@@ -201,7 +201,7 @@ lab.experiment('Flood service test', () => {
 
     Code.expect(result).to.equal('ok')
   })
-  lab.test('Test getRiverByName', async () => {
+  lab.test('Test getRiversByName', async () => {
     const util = require('../../server/util')
 
     sandbox
@@ -213,7 +213,7 @@ lab.experiment('Flood service test', () => {
 
     const floodService = require('../../server/services/flood')
 
-    const result = await floodService.getRiverByName('tyne')
+    const result = await floodService.getRiversByName('tyne')
 
     Code.expect(result).to.equal('ok')
   })


### PR DESCRIPTION
- https://eaflood.atlassian.net/browse/FSR-587
- sanitise query term passed to river search
- Change method name to better reflect purpose
