### PR TITLE
updated function to remove spikes over 300m

### DIFF
--- a/server/util.js
+++ b/server/util.js
@@ -70,9 +70,7 @@ function cleanseLocation (location) {
 }
 
 function removeSpikes (data) {
-  const anomalyVal = 100
-  const avg = data.reduce((a, b) => a + b._, 0) / data.length
-  const maxVal = avg * anomalyVal
+  const maxVal = 300
   return data.filter(el => el._ < maxVal)
 }
 

--- a/test/server/util.js
+++ b/test/server/util.js
@@ -51,11 +51,11 @@ lab.experiment('util', () => {
     lab.test('Fails gracefully with undefined name', async () => {
       Code.expect(formatName()).to.equal('')
     })
-    lab.test('Removes spike in telem, 480 values should be 479 values returned', async () => {
+    lab.test('Removes spike in telem over 300m, should be 479 values returned', async () => {
       const telem = removeSpikes(spikeTelem)
       Code.expect(telem.length).to.equal(479)
     })
-    lab.test('No spikes in telem, 480 values should be 480 values returned', async () => {
+    lab.test('No spikes in telem all values under 300m, 480 values returned', async () => {
       const telem = removeSpikes(nonSpikeTelem)
       Code.expect(telem.length).to.equal(480)
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FSR-702

Testing shown calculating the average wasnt the way to go, now remove all values over 300m