### PR TITLE
Release 6.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "flood-app",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "6.0.0",
+      "name": "flood-app",
+      "version": "6.1.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flood-app",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "Flood risk app",
   "main": "index.js",
   "repository": "github:defra/flood-app",

--- a/release-docs/CFF-6.1.0.txt
+++ b/release-docs/CFF-6.1.0.txt
@@ -1,0 +1,25 @@
+# Check for flooding 6.1.0 Thursday 16th February 2023
+
+# Release
+
+6.1.0
+
+https://eaflood.atlassian.net/projects/FSR/versions/16105/tab/release-report-all-issues
+
+# Tickets
+
+https://eaflood.atlassian.net/browse/FSR-700
+https://eaflood.atlassian.net/browse/FSR-702
+https://eaflood.atlassian.net/browse/FSR-703
+https://eaflood.atlassian.net/browse/FSR-728
+https://eaflood.atlassian.net/browse/FSR-656
+https://eaflood.atlassian.net/browse/FSR-693
+https://eaflood.atlassian.net/browse/FSR-734
+
+# Instructions
+
+Straight forward application build for release
+
+LFW_{stage}_04_UPDATE_FLOOD_APP_AND_SERVICE_PIPELINE
+
+Execute smoke tests and forward results

--- a/release-docs/CFF-6.1.0.txt
+++ b/release-docs/CFF-6.1.0.txt
@@ -20,6 +20,7 @@ https://eaflood.atlassian.net/browse/FSR-734
 
 Straight forward application build for release
 
-LFW_{stage}_04_UPDATE_FLOOD_APP_AND_SERVICE_PIPELINE
+1 - Execute LFW_{STAGE}_02_UPDATE_DATABASE
+2 - Execute LFW_{STAGE}_04_UPDATE_FLOOD_APP_AND_SERVICE_PIPELINE
 
 Execute smoke tests and forward results


### PR DESCRIPTION
# Check for flooding 6.1.0 Thursday 16th February 2023

# Release

6.1.0

https://eaflood.atlassian.net/projects/FSR/versions/16105/tab/release-report-all-issues

# Tickets

https://eaflood.atlassian.net/browse/FSR-700
https://eaflood.atlassian.net/browse/FSR-702
https://eaflood.atlassian.net/browse/FSR-703
https://eaflood.atlassian.net/browse/FSR-728
https://eaflood.atlassian.net/browse/FSR-656
https://eaflood.atlassian.net/browse/FSR-693
https://eaflood.atlassian.net/browse/FSR-734

# Instructions

Straight forward application build for release

1 - Execute LFW_{STAGE}_02_UPDATE_DATABASE
2 - Execute LFW_{STAGE}_04_UPDATE_FLOOD_APP_AND_SERVICE_PIPELINE

Execute smoke tests and forward results