### PR TITLE
FSR-867 Update related links

### DIFF
--- a/server/models/views/alerts-and-warnings.js
+++ b/server/models/views/alerts-and-warnings.js
@@ -11,6 +11,7 @@ class ViewModel {
       placeCentre: place ? place.center : [],
       timestamp: Date.now(),
       error: error ? true : null,
+      getWarnings: 'Alerts-and-warnings:Related-content:Get-warnings',
       isEngland: place ? place.isEngland.is_england : null,
       isDummyData: floods ? floods.isDummyData : false
     })

--- a/server/models/views/rainfall.js
+++ b/server/models/views/rainfall.js
@@ -18,6 +18,7 @@ class ViewModel {
       stationId: rainfallStation[0].station_reference,
       centroid: [rainfallStation[0].lon, rainfallStation[0].lat],
       region: rainfallStation[0].region,
+      getWarnings: 'Rainfall:Related-content:Get-warnings',
       planAhead: 'Rainfall:Related-content:Plan-ahead-for-flooding',
       whatToDo: 'Rainfall:Related-content:What-to-do-in-a-flood',
       recoverAfter: 'Rainfall:Related-content:Recover-after-a-flood',

--- a/server/models/views/river-and-sea-levels.js
+++ b/server/models/views/river-and-sea-levels.js
@@ -4,11 +4,14 @@ const { bingKeyMaps, floodRiskUrl } = require('../../config')
 const pageTitle = 'Find river, sea, groundwater and rainfall levels'
 const metaDescription = 'Find river, sea, groundwater and rainfall levels in England. Check the last updated height, trend and state recorded by the measuring station.'
 
+const getWarningsString = 'Rivers-and-sea-levels:Related-content:Get-warnings'
+
 function emptyResultsModel (q) {
   return {
     q,
     metaDescription,
     floodRiskUrl,
+    getWarnings: getWarningsString,
     pageTitle: formatTitle(q),
     clientModel: getClientModel()
   }
@@ -23,6 +26,7 @@ function disambiguationModel (q, places, rivers) {
     q,
     metaDescription,
     rivers,
+    getWarnings: getWarningsString,
     pageTitle: `${q} - ${pageTitle}`,
     place: places[0],
     clientModel: getClientModel()
@@ -47,6 +51,7 @@ function riverViewModel (stations) {
     queryGroup,
     floodRiskUrl,
     metaDescription,
+    getWarnings: getWarningsString,
     pageTitle: `${qualifiedRiverName} - ${pageTitle}`,
     q: qualifiedRiverName,
     clientModel: getClientModel(bbox)
@@ -70,6 +75,7 @@ function areaViewModel (areaName, stations) {
     floodRiskUrl,
     pageTitle,
     metaDescription,
+    getWarnings: getWarningsString,
     clientModel: getClientModel(bbox),
     distStatement: `Showing levels within 5 miles of ${areaName}.`
   }
@@ -95,6 +101,7 @@ function referencedStationViewModel (referencePoint, stations) {
     floodRiskUrl,
     pageTitle,
     metaDescription,
+    getWarnings: getWarningsString,
     clientModel: getClientModel(bbox),
     distStatement: referencePoint.distStatement
   }
@@ -133,6 +140,7 @@ function placeViewModel ({ location, place, stations = [], queryGroup }) {
     clientModel: getClientModel(isEngland ? place.bbox10k : []),
     queryGroup: activeFilter,
     placeAddress: place.address,
+    getWarnings: getWarningsString,
     pageTitle: title,
     metaDescription: description
   }

--- a/server/views/privacy-notice.html
+++ b/server/views/privacy-notice.html
@@ -53,23 +53,6 @@
      <p>If these changes affect how your personal data is processed, we'll take reasonable steps to let you know.</p>
      <p>This notice was last updated on 17 March 2022.</p>
   </div>
-  <div class="govuk-grid-column-one-third">
-     <div class="defra-related-items">
-        <h2 class="govuk-heading-s" id="subsection-title">
-           Related content
-        </h2>
-        <nav role="navigation" aria-labelledby="subsection-title">
-           <ul class="govuk-list govuk-!-font-size-16">
-              <li>
-                 <a href="/cookies">Cookies</a>
-              </li>
-              <li>
-                 <a href="/terms-and-conditions">Terms and conditions</a>
-              </li>
-           </ul>
-        </nav>
-     </div>
-  </div>
 </div>
 
 {% endblock %}

--- a/server/views/terms-and-conditions.html
+++ b/server/views/terms-and-conditions.html
@@ -119,24 +119,6 @@
     <p>Please check these terms and conditions regularly. We can update them at any time without notice.</p>
     <p>You’ll agree to any changes if you continue to use the service after the terms and conditions have been updated.</p>
   </div>
-
-  <div class="govuk-grid-column-one-third">
-    <div class="defra-related-items">
-      <h2 class="govuk-heading-s" id="subsection-title">
-        Related content
-      </h2>
-      <nav role="navigation" aria-labelledby="subsection-title">
-        <ul class="govuk-list govuk-!-font-size-16">
-          <li>
-            <a href="/cookies">Cookies</a>
-          </li>
-          <li>
-            <a href="https://www.gov.uk/government/organisations/environment-agency/about/personal-information-charter">Personal information charter</a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </div>
 </div>
 
 {% endblock %}

--- a/test/models/alerts-and-warnings.js
+++ b/test/models/alerts-and-warnings.js
@@ -59,3 +59,11 @@ lab.test('Test location sets page title', async () => {
 
   Code.expect(Result.pageTitle).to.equal('Newcastle Upon Tyne - flood alerts and warnings')
 })
+
+lab.test('Test getWarnings has appropriate Value', async () => {
+  const options = {}
+
+  const Result = await new ViewModel(options)
+
+  Code.expect(Result.getWarnings).to.equal('Alerts-and-warnings:Related-content:Get-warnings')
+})

--- a/test/models/rainfall.js
+++ b/test/models/rainfall.js
@@ -111,4 +111,12 @@ lab.experiment('Rainfall model test', () => {
     Code.expect(Result.postTitle).to.equal('Latest rainfall information at Lavenham gauge')
     Code.expect(Result.metaDescription).to.equal('Check the latest recorded rainfall at Lavenham gauge')
   })
+  lab.test('Test getWarnings has appropriate Value', async () => {
+    const rainfallTelemetryData = data.rainfallStationTelemetry
+    const rainfallStationData = data.rainfallStation.filter((rainfallStation) => rainfallStation.station_reference === 'E24195')
+
+    const result = new ViewModel(rainfallTelemetryData, rainfallStationData)
+
+    Code.expect(result.getWarnings).to.equal('Rainfall:Related-content:Get-warnings')
+  })
 })

--- a/test/models/river-and-sea-levels.js
+++ b/test/models/river-and-sea-levels.js
@@ -16,53 +16,64 @@ lab.experiment('river-and-sea-levels model test', () => {
   lab.afterEach(async () => {
     await sandbox.restore()
   })
-  lab.test('Test river-and-sea-level placeViewModel returns stations', async () => {
-    const stationsData = data.riverAndSeaLevelData
+  lab.experiment('placeViewModel', () => {
+    lab.test('Test river-and-sea-level placeViewModel returns stations', async () => {
+      const stationsData = data.riverAndSeaLevelData
 
-    const model = placeViewModel(stationsData)
+      const model = placeViewModel(stationsData)
 
-    Code.expect(model.stations.length).to.equal(76)
-    Code.expect(model.stations[0].river_name).to.equal('Valley Brook')
-    Code.expect(model.stations[0].region).to.equal('North West')
-  })
-  lab.test('Test river-and-sea-level placeViewModel returns stations in distance order from place', async () => {
-    const stationsData = data.riverAndSeaLevelDataUnordered
-    const firstStation = data.riverAndSeaLevelDataUnordered.stations[0]
-    const model = placeViewModel(stationsData)
-
-    Code.expect(model.stations[2].distance).to.be.greaterThan(model.stations[1].distance)
-    Code.expect(model.stations[0].river_name).to.not.equal(firstStation.river_name)
-    Code.expect(model.stations[0].region).to.equal('North West')
-  })
-  lab.test('Test river-and-sea-level placeViewModel filters stations into groups', async () => {
-    const stationsData = data.riverAndSeaLevelData
-    const model = placeViewModel(stationsData)
-
-    Code.expect(model.filters[0].count).to.equal(74)
-    Code.expect(model.filters[1].count).to.equal(0)
-    Code.expect(model.filters[2].count).to.equal(2)
-    Code.expect(model.filters[3].count).to.equal(0)
-  })
-  lab.test('Test river-and-sea-level placeViewModel returns formatted date time for stations', async () => {
-    const stationsData = data.riverAndSeaLevelData
-    const model = placeViewModel(stationsData)
-
-    Code.expect(model.stations[0].latestDatetime).to.equal('Latest at 5:30am on 16 July ')
-  })
-  lab.test('Test river-and-sea-level placeViewModel returns formattedValue with correct number of decimal places', async () => {
-    const stationsData = data.riverAndSeaLevelData
-    const model = placeViewModel(stationsData)
-
-    const station = model.stations.find(item => {
-      return item.station_type === 'S'
+      Code.expect(model.stations.length).to.equal(76)
+      Code.expect(model.stations[0].river_name).to.equal('Valley Brook')
+      Code.expect(model.stations[0].region).to.equal('North West')
     })
-    const rainfallStation = model.stations.find(item => {
-      return item.station_type === 'R'
+    lab.test('Test river-and-sea-level placeViewModel returns stations in distance order from place', async () => {
+      const stationsData = data.riverAndSeaLevelDataUnordered
+      const firstStation = data.riverAndSeaLevelDataUnordered.stations[0]
+      const model = placeViewModel(stationsData)
+
+      Code.expect(model.stations[2].distance).to.be.greaterThan(model.stations[1].distance)
+      Code.expect(model.stations[0].river_name).to.not.equal(firstStation.river_name)
+      Code.expect(model.stations[0].region).to.equal('North West')
+    })
+    lab.test('Test river-and-sea-level placeViewModel filters stations into groups', async () => {
+      const stationsData = data.riverAndSeaLevelData
+      const model = placeViewModel(stationsData)
+
+      Code.expect(model.filters[0].count).to.equal(74)
+      Code.expect(model.filters[1].count).to.equal(0)
+      Code.expect(model.filters[2].count).to.equal(2)
+      Code.expect(model.filters[3].count).to.equal(0)
+    })
+    lab.test('Test river-and-sea-level placeViewModel returns formatted date time for stations', async () => {
+      const stationsData = data.riverAndSeaLevelData
+      const model = placeViewModel(stationsData)
+
+      Code.expect(model.stations[0].latestDatetime).to.equal('Latest at 5:30am on 16 July ')
+    })
+    lab.test('Test river-and-sea-level placeViewModel returns formattedValue with correct number of decimal places', async () => {
+      const stationsData = data.riverAndSeaLevelData
+      const model = placeViewModel(stationsData)
+
+      const station = model.stations.find(item => {
+        return item.station_type === 'S'
+      })
+      const rainfallStation = model.stations.find(item => {
+        return item.station_type === 'R'
+      })
+
+      Code.expect(station.formattedValue).to.equal('0.22m')
+      Code.expect(rainfallStation.formattedValue).to.equal('0m')
     })
 
-    Code.expect(station.formattedValue).to.equal('0.22m')
-    Code.expect(rainfallStation.formattedValue).to.equal('0m')
+    lab.test('Test getWarnings has appropriate Value', async () => {
+      const stationsData = data.riverAndSeaLevelData
+
+      const result = placeViewModel(stationsData)
+
+      Code.expect(result.getWarnings).to.equal('Rivers-and-sea-levels:Related-content:Get-warnings')
+    })
   })
+
   lab.experiment('referencedStationViewModel', () => {
     lab.test('Test river-and-sea-level referencedStationViewModel sorts stations in distance order from rainfall station', async () => {
       const stationsData = data.riverAndSeaLevelDataUnordered
@@ -79,6 +90,20 @@ lab.experiment('river-and-sea-levels model test', () => {
       Code.expect(model.stations.length).to.equal(76)
       Code.expect(model.stations[1].distance).to.be.greaterThan(model.stations[0].distance)
       Code.expect(model.stations[2].distance).to.be.greaterThan(model.stations[1].distance)
+    })
+    lab.test('Test getWarnings has appropriate Value', async () => {
+      const stationsData = data.riverAndSeaLevelDataUnordered
+      const [rainfallStation] = data.rainfallStation553564
+
+      const referencePoint = {
+        name: rainfallStation.station_name,
+        lat: rainfallStation.lat,
+        lon: rainfallStation.lon
+      }
+
+      const result = referencedStationViewModel(referencePoint, stationsData.stations)
+
+      Code.expect(result.getWarnings).to.equal('Rivers-and-sea-levels:Related-content:Get-warnings')
     })
   })
 })


### PR DESCRIPTION
- Adds "Get flood warnings" to related links on:
  - "Alerts and warnings" page i.e. /alerts-and-warnings
  - "Rainfall station" page i.e. /rainfall-station/058461
  - "River and sea levels" pages i.e. /river-and-sea-levels?q=Harrogate
- Remove "related links" entirely from /privacy-notice and /terms-and-conditions

## Screenshots

### Before 
![check-for-flooding service gov uk_alerts-and-warnings](https://github.com/DEFRA/flood-app/assets/11778762/8f1ba480-8aee-44d9-af2a-fc5e7d67b761)

### After 
![localhost_3000_alerts-and-warnings (1)](https://github.com/DEFRA/flood-app/assets/11778762/6c2b5ebe-0739-41ef-b3d7-08fd4ad4039c)