### PR TITLE
FSR-744 | Viewport description fix 

### DIFF
--- a/server/src/templates/description-live.html
+++ b/server/src/templates/description-live.html
@@ -1,12 +1,13 @@
 {% if model.numFeatures > 9 %}
 <p>{{ model.numWarnings }} flood alerts or warnings and {{ model.mumMeasurements }} water level measurements in the current map area. To list these zoom in to nine or fewer.</p>
 {% elif model.numFeatures >= 1 %}
-<p>{{ model.numWarnings }} flood alerts or warnings and {{ model.mumMeasurements }} water level measurements in the current map area. Use number keys to select.</p>
-<ol>
-    {% for feature in model.features %}
-    <li>{{ feature.name }}</li>
-    {% endfor %}
-</ol>
+<p>
+{{ model.numWarnings }} flood alerts or warnings and {{ model.mumMeasurements }} water level measurements in the current map area. Use number keys to select.
+
+{% for feature in model.features %}
+    {{loop.index}}: {{ feature.name }};
+{% endfor %}
+</p>
 {% else %}
 <p>No flood alerts, warnings or water level measurements in the current map area.</p>
 {% endif %}


### PR DESCRIPTION
# FSR-744 Viewport description fix

## [WIP]
- During manual testing, a pre-existing issue was detected where blank options were present in the viewport description. This has been raised in the ticket and once an appropriate mitigation is identified, it'll be fixed as part of this PR.

## What
Moves viewport description text for map into a single `<p/>` tag.

## Why
This means that it'll be read out by screen-readers on first load.