### PR TITLE
FSR-887 - Buttons & Links | High Contrast

### DIFF
--- a/server/src/sass/objects/_buttons.scss
+++ b/server/src/sass/objects/_buttons.scss
@@ -9,10 +9,13 @@
         margin-left:5px;
         vertical-align: middle;
         top:-1px;
+        @media (forced-colors: active) {
+            color: currentColor;
+        }
     }
 }
 
-// Secondoary button
+// Secondary button
 a.defra-button-secondary,
 button.defra-button-secondary {
     position: relative;
@@ -47,7 +50,6 @@ button.defra-button-secondary {
     &--icon {
         padding-left: 31px;
         svg {
-            color: govuk-colour('black');
             position: absolute;
             left: 10px;
             top: 50%;
@@ -105,13 +107,22 @@ button.defra-button-secondary {
             margin-right: 8px;
             top: 4px;
         }
+        @media (forced-colors: active) {
+            color: currentColor;
+        }
     }
     &:hover svg {
         color: $govuk-link-hover-colour;
+        @media (forced-colors: active) {
+            color: currentColor;
+        }
     }
     &:focus svg,
     &:active svg {
         color: govuk-colour('black');
+        @media (forced-colors: active) {
+            color: currentColor;
+        }
     }
 }
 .defra-link-icon-s {

--- a/server/views/national.html
+++ b/server/views/national.html
@@ -56,6 +56,7 @@
 
     <a data-journey-click="National:Location search:National - Location search" href="/find-location" class="defra-button-start govuk-!-margin-bottom-7" data-module="govuk-button" role="button">
       Check for flooding near you
+      <svg focusable="false" aria-hidden="true" width="13" height="15" viewBox="0 0 13 15"><path d="M0.325,0l4.875,0l7.5,7.5l-7.5,7.5l-4.875,0l7.5,-7.5l-7.5,-7.5Z" fill="currentColor"></path></svg>
     </a>
 
     <h2 class="govuk-heading-m">Latest river, sea, groundwater and rainfall levels</h2>


### PR DESCRIPTION
# FSR-887 - Buttons & Links | High Contrast

## What
- Adds explicit unsetting of `color` on embedded svgs in high contrast mode. 

## Screenshots
_Note: screenshots taken in MS Edge on Windows 11 with High Contrast 'Aquatic' Theme_

### Map Button 
#### As-Is. 
![check-for-flooding service gov uk_river-and-sea-levels](https://github.com/DEFRA/flood-app/assets/11778762/7ed3627d-1fe2-4aed-96f4-9b2b938a4e23)

#### Updated. 
![localhost mac_3000_river-and-sea-levels](https://github.com/DEFRA/flood-app/assets/11778762/27071ba9-f18a-4b17-94ac-2d39a7e3e6fe)

### Secondary Start Button
#### As-Is. 
![check-for-flooding service gov uk_](https://github.com/DEFRA/flood-app/assets/11778762/b89b216b-0536-4891-9361-b3a38d2f6f60)

#### Updated. 
![localhost mac_3000_](https://github.com/DEFRA/flood-app/assets/11778762/23ea2dc9-d1b6-4bca-a674-f0c245ef2d10)



<TBC>