### PR TITLE
FSR-888 | High Contrast Mode on Search

### DIFF
--- a/server/src/sass/components/_search.scss
+++ b/server/src/sass/components/_search.scss
@@ -45,7 +45,6 @@
         z-index: 1;
         cursor: pointer;
         color: white;
-        outline: 3px solid transparent;
         svg {
             position:absolute;
             top: 8px;


### PR DESCRIPTION
# FSR-888 | High Contrast Mode on Search

## What
-  remove transparent outline on search button

## Screenshots
### Before
![check-for-flooding service gov uk_river-and-sea-levels (2)](https://github.com/DEFRA/flood-app/assets/11778762/58d8211e-c55f-4aee-b3f0-39c5929f1a0f)


### After
![localhost mac_3000_river-and-sea-levels (2)](https://github.com/DEFRA/flood-app/assets/11778762/ba744fcb-baf3-471b-a880-f201c778e1bc)

