### PR TITLE
FSR-889 - Banners | High Contrast

### DIFF
--- a/server/src/sass/components/_flood-status.scss
+++ b/server/src/sass/components/_flood-status.scss
@@ -14,6 +14,14 @@
     padding:0px;
     margin-top:0px;
     margin-bottom:10px;
+
+    @media (forced-colors: active) {
+        border-top-width: 1px;
+        border-bottom-width: 1px;
+        border-right-width: 1px;
+        border-style: solid;
+    }
+
     &:last-of-type {
         margin-bottom:5px;
     }


### PR DESCRIPTION
# FSR-889 - Banners | High Contrast

## What
- add thin top, right and bottom border to status items when colours are forced 

## Screenshots

### Before
![localhost mac_3000_ (2)](https://github.com/DEFRA/flood-app/assets/11778762/48345206-73fb-41d7-94cb-9ead2f165edc)

### After
![localhost mac_3000_ (1)](https://github.com/DEFRA/flood-app/assets/11778762/d930b417-39dc-427f-91ac-fed5fbcce833)

