### PR TITLE
FSR-890 - High Contrast Lists

### DIFF
--- a/server/src/sass/components/_flood-levels-table.scss
+++ b/server/src/sass/components/_flood-levels-table.scss
@@ -179,6 +179,9 @@
       left: 4px;
       top: 4px;
       color: govuk-colour('black');
+      @media (forced-colors: active) {
+        color: currentColor;
+      }
       @include mq ($from: tablet) {
         left:6px;
         top: 6px;

--- a/server/src/sass/components/_navbar.scss
+++ b/server/src/sass/components/_navbar.scss
@@ -91,7 +91,7 @@
       color: govuk-colour('black');
       background-color: transparent;
       svg {
-        color: govuk-colour('black');
+        color: currentColor;
       }
     }
     &:active {
@@ -166,7 +166,6 @@
       svg {
         position: relative;
         display: inline-block;
-        color: govuk-colour('black');
         vertical-align: top;
         left: 0px;
         margin: 0px 7px -3px 1px;
@@ -188,12 +187,15 @@
       color: $govuk-link-hover-colour;
       svg {
         color: $govuk-link-hover-colour;
+        @media (forced-colors: active) {
+          color: currentColor;
+        }
       }
     }
     .defra-navbar__item a:focus {
       color: govuk-colour('black');
       svg {
-        color: govuk-colour('black');
+        color: currentColor;
       }
     }
     .defra-navbar__item--selected a:not(:focus) {

--- a/server/src/sass/objects/_buttons.scss
+++ b/server/src/sass/objects/_buttons.scss
@@ -52,6 +52,9 @@ button.defra-button-secondary {
             left: 10px;
             top: 50%;
             margin-top: -11px;
+            @media (forced-colors: active) {
+                color: currentColor;
+            }
         }
     }
 }


### PR DESCRIPTION
# FSR-890 - High Contrast Lists

- removes explicit color applied to trend svg in css in hcm
- removes explicit color applied to nav svgs in css in hcm

## Screenshots

### Before
![localhost mac_3000_river-and-sea-levels_target-area_033WAF312 (1)](https://github.com/DEFRA/flood-app/assets/11778762/5e6dda4e-d1fe-482d-97fe-4700c006f10b)

### After
![localhost mac_3000_river-and-sea-levels_target-area_033WAF312](https://github.com/DEFRA/flood-app/assets/11778762/8795b199-9003-4a38-b2fd-60fdddc0878d)

