### PR TITLE
Tooling | add check for PR base branch name

### DIFF
--- a/.github/workflows/pr-base-check.yml
+++ b/.github/workflows/pr-base-check.yml
@@ -1,0 +1,25 @@
+name: "PR Base Branch Check"
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+jobs:
+  check-base-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check valid base branch
+        run: |
+          BASE_BRANCH="${{ github.event.pull_request.base.label }}"
+          SOURCE_BRANCH="${{ github.event.pull_request.head.label }}"
+          echo "Attempting to merge ${SOURCE_BRANCH} into ${BASE_BRANCH}"
+          if [ "$BASE_BRANCH" = "DEFRA:master" ]; then
+            echo base is master
+            if [[ "$SOURCE_BRANCH" != "DEFRA:release/"* ]] && [[ "$SOURCE_BRANCH" != "DEFRA:hotfix/"* ]]; then
+              echo Source is neither a "release" nor a "hotfix" branch, so cannot be merged to master.
+              exit 1
+            fi
+          fi
+          echo "Branches ok to be merged"
+      
+              
+


### PR DESCRIPTION
# Tooling | add check for PR base branch name

## What
This PR adds a github action which will fail a PR build if the PR is trying to merge a branch to `master` which isn't either the `development` branch or a `hotfix/` branch.

## Why
This is to prevent un-intended merges of PRs to master