### PR TITLE
FSR-1043 - fix unhandled 500 errors on /rainfall-station endpoints

### DIFF
--- a/server/models/views/rainfall.js
+++ b/server/models/views/rainfall.js
@@ -5,7 +5,10 @@ const util = require('../../util')
 
 class ViewModel {
   constructor (rainfallStationTelemetry, rainfallStation) {
-    const stationName = rainfallStation[0].station_name.replace(/(^\w|\s\w)(\S*)/g, (_, m1, m2) => m1.toUpperCase() + m2.toLowerCase())
+    const stationName = rainfallStation
+      .station_name
+      .replace(/(^\w|\s\w)(\S*)/g, (_, m1, m2) => m1.toUpperCase() + m2.toLowerCase())
+
     Object.assign(this, {
       stationName,
       pageTitle: 'Rainfall at ' + stationName + ' gauge',
@@ -15,9 +18,9 @@ class ViewModel {
       telemetry: rainfallStationTelemetry || [],
       floodRiskUrl: config.floodRiskUrl,
       bingMaps: config.bingKeyMaps,
-      stationId: rainfallStation[0].station_reference,
-      centroid: [rainfallStation[0].lon, rainfallStation[0].lat],
-      region: rainfallStation[0].region,
+      stationId: rainfallStation.station_reference,
+      centroid: [rainfallStation.lon, rainfallStation.lat],
+      region: rainfallStation.region,
       getWarnings: 'Rainfall:Related-content:Get-warnings',
       planAhead: 'Rainfall:Related-content:Plan-ahead-for-flooding',
       whatToDo: 'Rainfall:Related-content:What-to-do-in-a-flood',
@@ -37,9 +40,9 @@ class ViewModel {
       const rangeStartDateTime = fiveDaysAgo
       const dataEndDateTime = now
       const rangeEndDateTime = now
-      const latest1hr = util.formatValue(rainfallStation[0].one_hr_total)
-      const latest6hr = util.formatValue(rainfallStation[0].six_hr_total)
-      const latest24hr = util.formatValue(rainfallStation[0].day_total)
+      const latest1hr = util.formatValue(rainfallStation.one_hr_total)
+      const latest6hr = util.formatValue(rainfallStation.six_hr_total)
+      const latest24hr = util.formatValue(rainfallStation.day_total)
       const valueDuration = this.telemetry[0].period === '15 min' ? 15 : 45
       this.id = `${this.stationId}.${this.region}`
       const latestHourDateTime = moment(latestDateTime).add(45, 'minutes').minutes(0).seconds(0).milliseconds(0).toDate()

--- a/server/routes/rainfall-station.js
+++ b/server/routes/rainfall-station.js
@@ -8,15 +8,19 @@ module.exports = {
   handler: async (request, h) => {
     const { id } = request.params
 
-    const rainfallStationTelemetry = await request.server.methods.flood.getRainfallStationTelemetry(id)
-    const rainfallStation = await request.server.methods.flood.getRainfallStation(id)
+    const [
+      rainfallStation,
+      rainfallStationTelemetry
+    ] = await Promise.all([
+      request.server.methods.flood.getRainfallStation(id),
+      request.server.methods.flood.getRainfallStationTelemetry(id)
+    ])
 
-    // Null rainfallStationTelemetry, but in this case service should return a 404 error so i don't think this ever gets hit, defensive programming though
+    if (!rainfallStation) {
+      return boom.notFound('Rainfall station not found')
+    }
     if (!rainfallStationTelemetry) {
       return boom.notFound('No rainfall station telemetry data found')
-    }
-    if (!rainfallStation) {
-      return boom.notFound('No rainfall station data found')
     }
 
     const model = new ViewModel(rainfallStationTelemetry, rainfallStation)

--- a/test/data/hrRainfallStation.json
+++ b/test/data/hrRainfallStation.json
@@ -1,4 +1,4 @@
-[{
+{
     "telemetry_station_id": "735",
     "station_reference": "E5732",
     "region": "Anglian",
@@ -19,4 +19,4 @@
     "type": "R",
     "lat": 52.12387860645138,
     "lon": 0.9573268999313961
-  }]
+  }

--- a/test/models/rainfall.js
+++ b/test/models/rainfall.js
@@ -20,7 +20,7 @@ lab.experiment('Rainfall model test', () => {
 
   lab.test('Test Rainfall viewModel puts stationName as Title Case', async () => {
     const rainfallTelemetryData = data.rainfallStationTelemetry
-    const rainfallStationData = data.rainfallStation.filter(function (rainfallStation) { return rainfallStation.station_reference === 'E24195' })
+    const rainfallStationData = data.rainfallStation.find(item => item.station_reference === 'E24195')
     const viewModel = new ViewModel(rainfallTelemetryData, rainfallStationData)
     const Result = viewModel
 
@@ -30,7 +30,7 @@ lab.experiment('Rainfall model test', () => {
   })
   lab.test('Test Rainfall viewModel puts stationName as Title Case with multiple words in string', async () => {
     const rainfallTelemetryData = data.rainfallStationTelemetry
-    const rainfallStationData = data.rainfallStation.filter(function (rainfallStation) { return rainfallStation.station_reference === 'N24195' })
+    const rainfallStationData = data.rainfallStation.find(item => item.station_reference === 'N24195')
     const viewModel = new ViewModel(rainfallTelemetryData, rainfallStationData)
 
     const Result = viewModel
@@ -41,7 +41,7 @@ lab.experiment('Rainfall model test', () => {
   })
   lab.test('Test Rainfall viewModel returns telemetryRainfall data', async () => {
     const rainfallTelemetryData = data.rainfallStationTelemetry
-    const rainfallStationData = data.rainfallStation.filter(function (rainfallStation) { return rainfallStation.station_reference === 'E24195' })
+    const rainfallStationData = data.rainfallStation.find(item => item.station_reference === 'E24195')
     const viewModel = new ViewModel(rainfallTelemetryData, rainfallStationData)
 
     const Result = viewModel
@@ -59,7 +59,7 @@ lab.experiment('Rainfall model test', () => {
   })
   lab.test('Test dates are formatted correctly for the view', async () => {
     const rainfallTelemetryData = data.rainfallStationTelemetry
-    const rainfallStationData = data.rainfallStation.filter(function (rainfallStation) { return rainfallStation.station_reference === 'E24195' })
+    const rainfallStationData = data.rainfallStation.find(item => item.station_reference === 'E24195')
     const viewModel = new ViewModel(rainfallTelemetryData, rainfallStationData)
 
     const Result = viewModel
@@ -69,7 +69,7 @@ lab.experiment('Rainfall model test', () => {
   })
   lab.test('Test station id constructed correctly', async () => {
     const rainfallTelemetryData = data.rainfallStationTelemetry
-    const rainfallStationData = data.rainfallStation.filter(function (rainfallStation) { return rainfallStation.station_reference === 'E24195' })
+    const rainfallStationData = data.rainfallStation.find(item => item.station_reference === 'E24195')
     const viewModel = new ViewModel(rainfallTelemetryData, rainfallStationData)
 
     const Result = viewModel
@@ -78,7 +78,7 @@ lab.experiment('Rainfall model test', () => {
   })
   lab.test('Test lat/long are populated in centroid', async () => {
     const rainfallTelemetryData = data.rainfallStationTelemetry
-    const rainfallStationData = data.rainfallStation.filter(function (rainfallStation) { return rainfallStation.station_reference === 'E24195' })
+    const rainfallStationData = data.rainfallStation.find(item => item.station_reference === 'E24195')
     const viewModel = new ViewModel(rainfallTelemetryData, rainfallStationData)
     const Result = viewModel
 
@@ -102,7 +102,7 @@ lab.experiment('Rainfall model test', () => {
   })
   lab.test('Test metadata and social details returned correctly', async () => {
     const rainfallTelemetryData = data.rainfallStationTelemetry
-    const rainfallStationData = data.rainfallStation.filter(function (rainfallStation) { return rainfallStation.station_reference === 'E24195' })
+    const rainfallStationData = data.rainfallStation.find(item => item.station_reference === 'E24195')
     const viewModel = new ViewModel(rainfallTelemetryData, rainfallStationData)
 
     const Result = viewModel
@@ -113,7 +113,7 @@ lab.experiment('Rainfall model test', () => {
   })
   lab.test('Test getWarnings has appropriate Value', async () => {
     const rainfallTelemetryData = data.rainfallStationTelemetry
-    const rainfallStationData = data.rainfallStation.filter((rainfallStation) => rainfallStation.station_reference === 'E24195')
+    const rainfallStationData = data.rainfallStation.find(item => item.station_reference === 'E24195')
 
     const result = new ViewModel(rainfallTelemetryData, rainfallStationData)
 

--- a/test/routes/rainfall-station-csv.js
+++ b/test/routes/rainfall-station-csv.js
@@ -5,7 +5,6 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const sinon = require('sinon')
 const lab = exports.lab = Lab.script()
-// const data = require('../data')
 
 lab.experiment('Routes test - rainfall-station-csv', () => {
   let sandbox
@@ -16,8 +15,7 @@ lab.experiment('Routes test - rainfall-station-csv', () => {
     delete require.cache[require.resolve('../../server/services/flood.js')]
     sandbox = await sinon.createSandbox()
     server = Hapi.server({
-      port: 3000,
-      host: 'localhost'
+      port: 3000, host: 'localhost'
     })
 
     const rainfallStationCsvPlugin = {
@@ -48,21 +46,33 @@ lab.experiment('Routes test - rainfall-station-csv', () => {
   })
   lab.test('GET /rainfall-station-csv rainfall station', async () => {
     const options = {
-      method: 'GET',
-      url: '/rainfall-station-csv/E24195'
+      method: 'GET', url: '/rainfall-station-csv/E24195'
     }
     const floodService = require('../../server/services/flood')
 
-    const fakeRainfallStationData = () => {
-      return [{ telemetry_station_id: 950, station_reference: 'E24195', region: 'Anglian', station_name: 'LAVENHAM', ngr: 'TL9237348710', easting: 594000, northing: 243000, period: '15 min', units: 'mm', telemetry_value_parent_id: 96703927, value: 0, value_timestamp: '2022-02-09T09:15:00.000Z', day_total: 20.00, six_hr_total: 15.23, one_hr_total: 3.21, type: 'R', lat: 56.103262968744666, lon: 2.8074515304839753 }]
-    }
-    const fakeRainfallTelemetryData = () => [
-      {
-        period: '15 min',
-        value: 0.2,
-        value_timestamp: '2021-07-15T12:00:00Z'
-      }
-    ]
+    const fakeRainfallStationData = () => ({
+      telemetry_station_id: 950,
+      station_reference: 'E24195',
+      region: 'Anglian',
+      station_name: 'LAVENHAM',
+      ngr: 'TL9237348710',
+      easting: 594000,
+      northing: 243000,
+      period: '15 min',
+      units: 'mm',
+      telemetry_value_parent_id: 96703927,
+      value: 0,
+      value_timestamp: '2022-02-09T09:15:00.000Z',
+      day_total: 20.00,
+      six_hr_total: 15.23,
+      one_hr_total: 3.21,
+      type: 'R',
+      lat: 56.103262968744666,
+      lon: 2.8074515304839753
+    })
+    const fakeRainfallTelemetryData = () => [{
+      period: '15 min', value: 0.2, value_timestamp: '2021-07-15T12:00:00Z'
+    }]
 
     sandbox.stub(floodService, 'getRainfallStation').callsFake(fakeRainfallStationData)
     sandbox.stub(floodService, 'getRainfallStationTelemetry').callsFake(fakeRainfallTelemetryData)
@@ -75,21 +85,33 @@ lab.experiment('Routes test - rainfall-station-csv', () => {
   })
   lab.test('GET /rainfall-station-csv test station name not capitalised', async () => {
     const options = {
-      method: 'GET',
-      url: '/rainfall-station-csv/E24195'
+      method: 'GET', url: '/rainfall-station-csv/E24195'
     }
     const floodService = require('../../server/services/flood')
 
-    const fakeRainfallStationData = () => {
-      return [{ telemetry_station_id: 950, station_reference: 'E24195', region: 'Anglian', station_name: 'LAVENHAM', ngr: 'TL9237348710', easting: 594000, northing: 243000, period: '15 min', units: 'mm', telemetry_value_parent_id: 96703927, value: 0, value_timestamp: '2022-02-09T09:15:00.000Z', day_total: 20.00, six_hr_total: 15.23, one_hr_total: 3.21, type: 'R', lat: 56.103262968744666, lon: 2.8074515304839753 }]
-    }
-    const fakeRainfallTelemetryData = () => [
-      {
-        period: '15 min',
-        value: 0.2,
-        value_timestamp: '2021-07-15T12:00:00Z'
-      }
-    ]
+    const fakeRainfallStationData = () => ({
+      telemetry_station_id: 950,
+      station_reference: 'E24195',
+      region: 'Anglian',
+      station_name: 'LAVENHAM',
+      ngr: 'TL9237348710',
+      easting: 594000,
+      northing: 243000,
+      period: '15 min',
+      units: 'mm',
+      telemetry_value_parent_id: 96703927,
+      value: 0,
+      value_timestamp: '2022-02-09T09:15:00.000Z',
+      day_total: 20.00,
+      six_hr_total: 15.23,
+      one_hr_total: 3.21,
+      type: 'R',
+      lat: 56.103262968744666,
+      lon: 2.8074515304839753
+    })
+    const fakeRainfallTelemetryData = () => [{
+      period: '15 min', value: 0.2, value_timestamp: '2021-07-15T12:00:00Z'
+    }]
 
     sandbox.stub(floodService, 'getRainfallStation').callsFake(fakeRainfallStationData)
     sandbox.stub(floodService, 'getRainfallStationTelemetry').callsFake(fakeRainfallTelemetryData)
@@ -100,21 +122,33 @@ lab.experiment('Routes test - rainfall-station-csv', () => {
   })
   lab.test('GET /rainfall-station-csv test telemetry results are padded to 5 days', async () => {
     const options = {
-      method: 'GET',
-      url: '/rainfall-station-csv/E24195'
+      method: 'GET', url: '/rainfall-station-csv/E24195'
     }
     const floodService = require('../../server/services/flood')
 
-    const fakeRainfallStationData = () => {
-      return [{ telemetry_station_id: 950, station_reference: 'E24195', region: 'Anglian', station_name: 'LAVENHAM', ngr: 'TL9237348710', easting: 594000, northing: 243000, period: '15 min', units: 'mm', telemetry_value_parent_id: 96703927, value: 0, value_timestamp: '2022-02-09T09:15:00.000Z', day_total: 20.00, six_hr_total: 15.23, one_hr_total: 3.21, type: 'R', lat: 56.103262968744666, lon: 2.8074515304839753 }]
-    }
-    const fakeRainfallTelemetryData = () => [
-      {
-        period: '15 min',
-        value: 0.2,
-        value_timestamp: '2021-07-15T12:00:00Z'
-      }
-    ]
+    const fakeRainfallStationData = () => ({
+      telemetry_station_id: 950,
+      station_reference: 'E24195',
+      region: 'Anglian',
+      station_name: 'LAVENHAM',
+      ngr: 'TL9237348710',
+      easting: 594000,
+      northing: 243000,
+      period: '15 min',
+      units: 'mm',
+      telemetry_value_parent_id: 96703927,
+      value: 0,
+      value_timestamp: '2022-02-09T09:15:00.000Z',
+      day_total: 20.00,
+      six_hr_total: 15.23,
+      one_hr_total: 3.21,
+      type: 'R',
+      lat: 56.103262968744666,
+      lon: 2.8074515304839753
+    })
+    const fakeRainfallTelemetryData = () => [{
+      period: '15 min', value: 0.2, value_timestamp: '2021-07-15T12:00:00Z'
+    }]
 
     sandbox.stub(floodService, 'getRainfallStation').callsFake(fakeRainfallStationData)
     sandbox.stub(floodService, 'getRainfallStationTelemetry').callsFake(fakeRainfallTelemetryData)
@@ -124,5 +158,66 @@ lab.experiment('Routes test - rainfall-station-csv', () => {
     const count = (response.result.match(/\n/g) || []).length
 
     Code.expect(count).to.equal(480)
+  })
+
+  lab.test('GET /rainfall-station-csv test return 404 if no station', async () => {
+    const options = {
+      method: 'GET', url: '/rainfall-station-csv/E24195'
+    }
+    const floodService = require('../../server/services/flood')
+
+    const fakeRainfallStationData = () => {}
+    const fakeRainfallTelemetryData = () => [{
+      period: '15 min', value: 0.2, value_timestamp: '2021-07-15T12:00:00Z'
+    }]
+
+    sandbox.stub(floodService, 'getRainfallStation').callsFake(fakeRainfallStationData)
+    sandbox.stub(floodService, 'getRainfallStationTelemetry').callsFake(fakeRainfallTelemetryData)
+
+    const response = await server.inject(options)
+
+    Code.expect(response.statusCode).to.equal(404)
+    Code.expect(response.result.statusCode).to.equal(404)
+    Code.expect(response.result.error).to.equal('Not Found')
+    Code.expect(response.result.message).to.equal('Rainfall station not found')
+  })
+
+  lab.test('GET /rainfall-station-csv test return 404 if no station', async () => {
+    const options = {
+      method: 'GET', url: '/rainfall-station-csv/E24195'
+    }
+    const floodService = require('../../server/services/flood')
+
+    const fakeRainfallStationData = () => ({
+      telemetry_station_id: 950,
+      station_reference: 'E24195',
+      region: 'Anglian',
+      station_name: 'LAVENHAM',
+      ngr: 'TL9237348710',
+      easting: 594000,
+      northing: 243000,
+      period: '15 min',
+      units: 'mm',
+      telemetry_value_parent_id: 96703927,
+      value: 0,
+      value_timestamp: '2022-02-09T09:15:00.000Z',
+      day_total: 20.00,
+      six_hr_total: 15.23,
+      one_hr_total: 3.21,
+      type: 'R',
+      lat: 56.103262968744666,
+      lon: 2.8074515304839753
+    })
+    const fakeRainfallTelemetryData = () => {}
+
+    sandbox.stub(floodService, 'getRainfallStation').callsFake(fakeRainfallStationData)
+    sandbox.stub(floodService, 'getRainfallStationTelemetry').callsFake(fakeRainfallTelemetryData)
+
+    const response = await server.inject(options)
+
+    Code.expect(response.statusCode).to.equal(404)
+    Code.expect(response.result.statusCode).to.equal(404)
+    Code.expect(response.result.error).to.equal('Not Found')
+    Code.expect(response.result.message).to.equal('No rainfall station telemetry data found')
   })
 })

--- a/test/routes/rainfall-station.js
+++ b/test/routes/rainfall-station.js
@@ -63,25 +63,23 @@ lab.experiment('Test - /rainfall-station', () => {
       }
     ]
 
-    const fakeRainfallStationData = () => [
-      {
-        telemetry_station_id: '950',
-        station_reference: 'E24195',
-        region: 'Anglian',
-        station_name: 'LAVENHAM',
-        centroid: '0101000020E610000010159197A4D6E93FB7D290B8370Q3T30',
-        data_type: 'Total',
-        period: '15 min',
-        units: 'mm',
-        telemetry_value_parent_id: '96504866',
-        value: '0',
-        value_timestamp: '2022-02-08T09:15:00.000Z',
-        day_total: '15.00',
-        six_hr_total: '55.00',
-        one_hr_total: '65.27',
-        type: 'R'
-      }
-    ]
+    const fakeRainfallStationData = () => ({
+      telemetry_station_id: '950',
+      station_reference: 'E24195',
+      region: 'Anglian',
+      station_name: 'LAVENHAM',
+      centroid: '0101000020E610000010159197A4D6E93FB7D290B8370Q3T30',
+      data_type: 'Total',
+      period: '15 min',
+      units: 'mm',
+      telemetry_value_parent_id: '96504866',
+      value: '0',
+      value_timestamp: '2022-02-08T09:15:00.000Z',
+      day_total: '15.00',
+      six_hr_total: '55.00',
+      one_hr_total: '65.27',
+      type: 'R'
+    })
 
     sandbox.stub(floodService, 'getRainfallStationTelemetry').callsFake(fakeRainfallStationTelemetryData)
     sandbox.stub(floodService, 'getRainfallStation').callsFake(fakeRainfallStationData)
@@ -128,25 +126,23 @@ lab.experiment('Test - /rainfall-station', () => {
       }
     ]
 
-    const fakeRainfallStationData = () => [
-      {
-        telemetry_station_id: '950',
-        station_reference: 'E24195',
-        region: 'Anglian',
-        station_name: 'LAVENHAM',
-        centroid: '0101000020E610000010159197A4D6E93FB7D290B8370Q3T30',
-        data_type: 'Total',
-        period: '15 min',
-        units: 'mm',
-        telemetry_value_parent_id: '96504866',
-        value: '0',
-        value_timestamp: '2022-02-08T09:15:00.000Z',
-        day_total: '15.00',
-        six_hr_total: '55.00',
-        one_hr_total: '65.27',
-        type: 'R'
-      }
-    ]
+    const fakeRainfallStationData = () => ({
+      telemetry_station_id: '950',
+      station_reference: 'E24195',
+      region: 'Anglian',
+      station_name: 'LAVENHAM',
+      centroid: '0101000020E610000010159197A4D6E93FB7D290B8370Q3T30',
+      data_type: 'Total',
+      period: '15 min',
+      units: 'mm',
+      telemetry_value_parent_id: '96504866',
+      value: '0',
+      value_timestamp: '2022-02-08T09:15:00.000Z',
+      day_total: '15.00',
+      six_hr_total: '55.00',
+      one_hr_total: '65.27',
+      type: 'R'
+    })
 
     sandbox.stub(floodService, 'getRainfallStationTelemetry').callsFake(fakeRainfallStationTelemetryData)
     sandbox.stub(floodService, 'getRainfallStation').callsFake(fakeRainfallStationData)
@@ -188,25 +184,23 @@ lab.experiment('Test - /rainfall-station', () => {
       }
     ]
 
-    const fakeRainfallStationData = () => [
-      {
-        telemetry_station_id: '950',
-        station_reference: 'E24195',
-        region: 'Anglian',
-        station_name: 'LAVENHAM',
-        centroid: '0101000020E610000010159197A4D6E93FB7D290B8370Q3T30',
-        data_type: 'Total',
-        period: '15 min',
-        units: 'mm',
-        telemetry_value_parent_id: '96504866',
-        value: '0',
-        value_timestamp: '2022-02-08T09:15:00.000Z',
-        day_total: '15.00',
-        six_hr_total: '55.00',
-        one_hr_total: '65.27',
-        type: 'R'
-      }
-    ]
+    const fakeRainfallStationData = () => ({
+      telemetry_station_id: '950',
+      station_reference: 'E24195',
+      region: 'Anglian',
+      station_name: 'LAVENHAM',
+      centroid: '0101000020E610000010159197A4D6E93FB7D290B8370Q3T30',
+      data_type: 'Total',
+      period: '15 min',
+      units: 'mm',
+      telemetry_value_parent_id: '96504866',
+      value: '0',
+      value_timestamp: '2022-02-08T09:15:00.000Z',
+      day_total: '15.00',
+      six_hr_total: '55.00',
+      one_hr_total: '65.27',
+      type: 'R'
+    })
 
     sandbox.stub(floodService, 'getRainfallStationTelemetry').callsFake(fakeRainfallStationTelemetryData)
     sandbox.stub(floodService, 'getRainfallStation').callsFake(fakeRainfallStationData)
@@ -249,25 +243,23 @@ lab.experiment('Test - /rainfall-station', () => {
       }
     ]
 
-    const fakeRainfallStationData = () => [
-      {
-        telemetry_station_id: '950',
-        station_reference: 'E24195',
-        region: 'Anglian',
-        station_name: 'LAVENHAM',
-        centroid: '0101000020E610000010159197A4D6E93FB7D290B8370Q3T30',
-        data_type: 'Total',
-        period: '15 min',
-        units: 'mm',
-        telemetry_value_parent_id: '96504866',
-        value: '0',
-        value_timestamp: '2022-02-08T09:15:00.000Z',
-        day_total: '15.00',
-        six_hr_total: '55.00',
-        one_hr_total: '65.27',
-        type: 'R'
-      }
-    ]
+    const fakeRainfallStationData = () => ({
+      telemetry_station_id: '950',
+      station_reference: 'E24195',
+      region: 'Anglian',
+      station_name: 'LAVENHAM',
+      centroid: '0101000020E610000010159197A4D6E93FB7D290B8370Q3T30',
+      data_type: 'Total',
+      period: '15 min',
+      units: 'mm',
+      telemetry_value_parent_id: '96504866',
+      value: '0',
+      value_timestamp: '2022-02-08T09:15:00.000Z',
+      day_total: '15.00',
+      six_hr_total: '55.00',
+      one_hr_total: '65.27',
+      type: 'R'
+    })
 
     sandbox.stub(floodService, 'getRainfallStationTelemetry').callsFake(fakeRainfallStationTelemetryData)
     sandbox.stub(floodService, 'getRainfallStation').callsFake(fakeRainfallStationData)
@@ -297,5 +289,48 @@ lab.experiment('Test - /rainfall-station', () => {
     const response = await server.inject(options)
 
     Code.expect(response.payload).to.contain('<h2 class="defra-service-error__title" id="error-summary-title">This measuring station is closed</h2>')
+  })
+
+  lab.test('GET /rainfall-station produces not found', async () => {
+    const floodService = require('../../server/services/flood')
+
+    const fakeRainfallStationTelemetryData = () => [
+      {
+        period: '15 min',
+        value: '0',
+        value_timestamp: moment().subtract(40, 'days').format()
+      }
+    ]
+
+    const fakeRainfallStationData = () => {}
+
+    sandbox.stub(floodService, 'getRainfallStationTelemetry').callsFake(fakeRainfallStationTelemetryData)
+    sandbox.stub(floodService, 'getRainfallStation').callsFake(fakeRainfallStationData)
+
+    const rainfallPlugin = {
+      plugin: {
+        name: 'rainfall-station',
+        register: (server, options) => {
+          server.route(require('../../server/routes/rainfall-station'))
+        }
+      }
+    }
+
+    await server.register(require('../../server/plugins/views'))
+    await server.register(require('../../server/plugins/session'))
+    await server.register(rainfallPlugin)
+    // Add Cache methods to server
+    const registerServerMethods = require('../../server/services/server-methods')
+    registerServerMethods(server)
+
+    await server.initialize()
+    const options = {
+      method: 'GET',
+      url: '/rainfall-station/E24195'
+    }
+
+    const response = await server.inject(options)
+
+    Code.expect(response.payload).to.contain('{"statusCode":404,"error":"Not Found","message":"Rainfall station not found"}')
   })
 })


### PR DESCRIPTION
**NOTE: This PR should be tested/released in tandem with https://github.com/DEFRA/flood-service/pull/150**

# What
- Update `getRainfallStation()` to expect object from flood-service rather than an array
- Update consumers of `getRainfallStation()` to expect object rather than an array
- Update routes depending on `getRainfallStation()` to respond 404 if no object is returned from the function
