### PR TITLE
hotfix: fix river-and-sea-levels looking up rainfall station

### DIFF
--- a/server/routes/river-and-sea-levels.js
+++ b/server/routes/river-and-sea-levels.js
@@ -77,10 +77,9 @@ module.exports = [{
   path: `/${route}/rainfall/{rainfallid}`,
   handler: async (request, h) => {
     const { rainfallid } = request.params
-    const rainfallStations = await request.server.methods.flood.getRainfallStation(rainfallid)
+    const rainfallStation = await request.server.methods.flood.getRainfallStation(rainfallid)
 
-    if (rainfallStations.length > 0) {
-      const rainfallStation = rainfallStations[0]
+    if (rainfallStation) {
       const radius = 8000 // metres
       const distanceInMiles = Math.round(radius / 1609.344)
       const referencePoint = {

--- a/test/data/cachedRainfallStation.json
+++ b/test/data/cachedRainfallStation.json
@@ -1,24 +1,22 @@
-[
-    {
-       "telemetry_station_id":"912",
-       "station_reference":"E27601",
-       "region":"Anglian",
-       "station_name":"EASTHAVEN BARRIER",
-       "ngr":"TQ7480084300",
-       "easting":574800,
-       "northing":184300,
-       "centroid":"0101000020E6100000A9324274F298E03FCC026A09E9C34940",
-       "data_type":"Total",
-       "period":"15 min",
-       "units":"mm",
-       "telemetry_value_parent_id":"105675541",
-       "value":"0",
-       "value_timestamp":"2022-03-25T04:30:00.000Z",
-       "day_total":"0",
-       "six_hr_total":"0",
-       "one_hr_total":"0",
-       "type":"R",
-       "lat":51.34453211,
-       "lon": -0.60409807
-    }
- ]
+{
+  "telemetry_station_id": "912",
+  "station_reference": "E27601",
+  "region": "Anglian",
+  "station_name": "EASTHAVEN BARRIER",
+  "ngr": "TQ7480084300",
+  "easting": 574800,
+  "northing": 184300,
+  "centroid": "0101000020E6100000A9324274F298E03FCC026A09E9C34940",
+  "data_type": "Total",
+  "period": "15 min",
+  "units": "mm",
+  "telemetry_value_parent_id": "105675541",
+  "value": "0",
+  "value_timestamp": "2022-03-25T04:30:00.000Z",
+  "day_total": "0",
+  "six_hr_total": "0",
+  "one_hr_total": "0",
+  "type": "R",
+  "lat": 51.34453211,
+  "lon": -0.60409807
+}

--- a/test/routes/river-and-sea-levels.js
+++ b/test/routes/river-and-sea-levels.js
@@ -1686,7 +1686,7 @@ lab.experiment('Test - /river-and-sea-levels', () => {
 
     const fakeStationsData = () => data.stationsWithinRadius
 
-    const originalStation = () => data.rainfallStation.filter(function (rainfallStation) {
+    const originalStation = () => data.rainfallStation.find(function (rainfallStation) {
       return rainfallStation.station_reference === 'GKHLETOY'
     })
 


### PR DESCRIPTION
fixes river-and-sea-levels page looking up rainfall station and expecting it to be an array with a single member instead of an object