### PR TITLE
FSR-1061 | Add redis cache to location.find method usage.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ const pino = require('./server/lib/pino')
 
 createServer()
   .then((server) => {
+    server.listener.requestTimeout = 0
+    server.listener.headersTimeout = 0
     server.start()
   })
   .catch(err => {

--- a/server/routes/alerts-and-warnings.js
+++ b/server/routes/alerts-and-warnings.js
@@ -1,7 +1,6 @@
 const joi = require('@hapi/joi')
 const ViewModel = require('../models/views/alerts-and-warnings')
 const Floods = require('../models/floods')
-const locationService = require('../services/location')
 const util = require('../util')
 
 module.exports = [{
@@ -27,7 +26,7 @@ module.exports = [{
       return h.view('alerts-and-warnings', { model })
     } else {
       try {
-        [place] = await locationService.find(util.cleanseLocation(location))
+        [place] = await request.server.methods.location.find(util.cleanseLocation(location))
       } catch (error) {
         request.logger.warn({
           situation: `Location search error: [${error.name}] [${error.message}]`,

--- a/server/routes/api/outlook.js
+++ b/server/routes/api/outlook.js
@@ -6,7 +6,7 @@ module.exports = {
   options: {
     description: 'Get outlook geojson data from cache',
     handler: async request => {
-      const { geoJson } = new OutlookModel(await request.server.methods.flood.getOutlook())
+      const { geoJson } = new OutlookModel(await request.server.methods.flood.getOutlook(), request.logger)
       return geoJson
     },
     app: {

--- a/server/routes/api/warnings.js
+++ b/server/routes/api/warnings.js
@@ -1,7 +1,6 @@
 const Joi = require('@hapi/joi')
 const Floods = require('../../models/floods')
 const floodsMessage = require('../../models/floods-message')
-const locationService = require('../../services/location')
 const util = require('../../util')
 
 module.exports = {
@@ -13,7 +12,7 @@ module.exports = {
       const location = util.cleanseLocation(request.query.location)
       let data, place
       if (location) {
-        [place] = await locationService.find(util.cleanseLocation(location))
+        [place] = await request.server.methods.location.find(util.cleanseLocation(location))
       }
 
       if (place) {

--- a/server/routes/location.js
+++ b/server/routes/location.js
@@ -1,7 +1,6 @@
 const joi = require('@hapi/joi')
 const ViewModel = require('../models/views/location')
 const OutlookTabsModel = require('../models/outlook-tabs')
-const locationService = require('../services/location')
 const util = require('../util')
 const formatDate = require('../util').formatDate
 const moment = require('moment-timezone')
@@ -21,7 +20,7 @@ module.exports = {
       return h.view('location-not-found', { pageTitle: 'Error: Find location - Check for flooding', location })
     }
 
-    const [place] = await locationService.find(util.cleanseLocation(location))
+    const [place] = await request.server.methods.location.find(util.cleanseLocation(location))
 
     if (!place) {
       return h.view('location-not-found', { pageTitle: 'Error: Find location - Check for flooding', location })

--- a/server/routes/river-and-sea-levels.js
+++ b/server/routes/river-and-sea-levels.js
@@ -10,7 +10,6 @@ const {
   disambiguationModel,
   emptyResultsModel
 } = require('../models/views/river-and-sea-levels')
-const locationService = require('../services/location')
 const util = require('../util')
 const route = 'river-and-sea-levels'
 
@@ -171,7 +170,7 @@ async function locationQueryHandler (request, h) {
   const cleanLocation = util.cleanseLocation(location)
   if (cleanLocation && cleanLocation.length > 1 && !cleanLocation.match(/^england$/i)) {
     if (includeTypes.includes('place')) {
-      places = await findPlaces(cleanLocation)
+      places = await findPlaces(request, cleanLocation)
     }
     if (includeTypes.includes('river')) {
       rivers = await request.server.methods.flood.getRiversByName(cleanLocation)
@@ -198,9 +197,9 @@ async function locationQueryHandler (request, h) {
 
 const inUk = place => place?.isUK && !place?.isScotlandOrNorthernIreland
 
-async function findPlaces (location) {
+async function findPlaces (request, location) {
   // NOTE: at the moment locationService.find just returns a single place
   // using the [] for no results and with a nod to upcoming work to return >1 result
-  const [place] = await locationService.find(location)
+  const [place] = await request.server.methods.location.find(location)
   return inUk(place) ? [place] : []
 }

--- a/server/services/server-methods.js
+++ b/server/services/server-methods.js
@@ -3,6 +3,9 @@ const locationService = require('./location')
 const config = require('../config')
 const cacheType = config.localCache ? undefined : 'redis_cache'
 
+const seconds = secs => secs * 1000
+const minutes = min => seconds(min * 60)
+
 // Cache method wrapper for hapi server
 // If we have any service calls we want to store in elasticache (in memory cache if localCache)
 // add them to the server.method with appropriate cache settings
@@ -13,16 +16,16 @@ module.exports = server => {
   server.method('flood.getFloods', floodServices.getFloods, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getFloodsWithin', floodServices.getFloodsWithin, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     },
     generateKey: array => array.join(',') // functions with array or object var need a non default key
   })
@@ -30,48 +33,48 @@ module.exports = server => {
   server.method('flood.getFloodArea', floodServices.getFloodArea, {
     cache: {
       cache: cacheType,
-      expiresIn: 15 * 60 * 1000, // 15 minutes
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(15),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getOutlook', floodServices.getOutlook, {
     cache: {
       cache: cacheType,
-      expiresIn: 15 * 60 * 1000, // 15 minutes
-      generateTimeout: 30 * 1000 // 30 seconds
+      expiresIn: minutes(15),
+      generateTimeout: seconds(30)
     }
   })
 
   server.method('flood.getStationById', floodServices.getStationById, {
     cache: {
       cache: cacheType,
-      expiresIn: 15 * 60 * 1000, // 15 minutes
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(15),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getStations', floodServices.getStations, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getRiversByName', floodServices.getRiversByName, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getStationsWithin', floodServices.getStationsWithin, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     },
     generateKey: array => array.join(',') // functions with array or object var need a non default key
   })
@@ -79,104 +82,104 @@ module.exports = server => {
   server.method('flood.getStationsWithinTargetArea', floodServices.getStationsWithinTargetArea, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getWarningsAlertsWithinStationBuffer', floodServices.getWarningsAlertsWithinStationBuffer, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getRiverById', floodServices.getRiverById, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getRiverStationByStationId', floodServices.getRiverStationByStationId, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getStationTelemetry', floodServices.getStationTelemetry, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getStationForecastThresholds', floodServices.getStationForecastThresholds, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getStationImtdThresholds', floodServices.getStationImtdThresholds, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getStationForecastData', floodServices.getStationForecastData, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getStationsGeoJson', floodServices.getStationsGeoJson, {
     cache: {
       cache: cacheType,
-      expiresIn: 15 * 60 * 1000, // 15 minutes
-      generateTimeout: 30 * 1000 // 30 seconds
+      expiresIn: minutes(15),
+      generateTimeout: seconds(30)
     }
   })
 
   server.method('flood.getRainfallGeojson', floodServices.getRainfallGeojson, {
     cache: {
       cache: cacheType,
-      expiresIn: 15 * 60 * 1000, // 15 minutes
-      generateTimeout: 30 * 1000 // 30 seconds
+      expiresIn: minutes(15),
+      generateTimeout: seconds(30)
     }
   })
 
   server.method('flood.getIsEngland', floodServices.getIsEngland, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getImpactData', floodServices.getImpactData, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getImpactsWithin', floodServices.getImpactsWithin, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     },
     generateKey: array => array.join(',') // functions with array or object var need a non default key
   })
@@ -184,56 +187,56 @@ module.exports = server => {
   server.method('flood.getRivers', floodServices.getRivers, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getStationsOverview', floodServices.getStationsOverview, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getTargetArea', floodServices.getTargetArea, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getStationsByRadius', floodServices.getStationsByRadius, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getRainfallStationTelemetry', floodServices.getRainfallStationTelemetry, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('flood.getRainfallStation', floodServices.getRainfallStation, {
     cache: {
       cache: cacheType,
-      expiresIn: 1 * 60 * 1000, // 1 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(1),
+      generateTimeout: seconds(10)
     }
   })
 
   server.method('location.find', locationService.find, {
     cache: {
       cache: cacheType,
-      expiresIn: 15 * 60 * 1000, // 15 minute
-      generateTimeout: 10 * 1000 // 10 seconds
+      expiresIn: minutes(15),
+      generateTimeout: seconds(10)
     }
   })
 }

--- a/server/services/server-methods.js
+++ b/server/services/server-methods.js
@@ -1,4 +1,5 @@
 const floodServices = require('./flood')
+const locationService = require('./location')
 const config = require('../config')
 const cacheType = config.localCache ? undefined : 'redis_cache'
 
@@ -224,6 +225,14 @@ module.exports = server => {
     cache: {
       cache: cacheType,
       expiresIn: 1 * 60 * 1000, // 1 minute
+      generateTimeout: 10 * 1000 // 10 seconds
+    }
+  })
+
+  server.method('location.find', locationService.find, {
+    cache: {
+      cache: cacheType,
+      expiresIn: 15 * 60 * 1000, // 15 minute
       generateTimeout: 10 * 1000 // 10 seconds
     }
   })

--- a/test/routes/alerts-and-warnings.js
+++ b/test/routes/alerts-and-warnings.js
@@ -108,6 +108,9 @@ lab.experiment('Test - /alerts-warnings', () => {
     await server.register(require('../../server/plugins/session'))
     await server.register(require('../../server/plugins/logging'))
     await server.register(warningsPlugin)
+    // Add Cache methods to server
+    const registerServerMethods = require('../../server/services/server-methods')
+    registerServerMethods(server)
 
     await server.initialize()
     const options = {
@@ -147,6 +150,9 @@ lab.experiment('Test - /alerts-warnings', () => {
     await server.register(require('../../server/plugins/session'))
     await server.register(require('../../server/plugins/logging'))
     await server.register(warningsPlugin)
+    // Add Cache methods to server
+    const registerServerMethods = require('../../server/services/server-methods')
+    registerServerMethods(server)
 
     await server.initialize()
     const options = {


### PR DESCRIPTION
# Add redis cache to location.find method usage.

## What
- adds server method for `locationService.find(location)`
- updates usages of `locationService.find(location)` to use new server method (except status route)
- refactoring of tests for alerts-and-warnings route*
- refactoring of server-methods to do millisecond maths in functions rather than inline (for clarity)

\* this is on a separate commit. The refactoring consists of consolidating the stubbing out of the `floodService` and `util.getJson`, as well as the common server setup, into the beforeEach step. No assertions or test data has been changed.