### PR TITLE
hotfix | outlook polys performance refactoring

### DIFF
--- a/server/models/outlook-polys.js
+++ b/server/models/outlook-polys.js
@@ -1,8 +1,8 @@
 const turf = require('@turf/turf')
 
-class OutlookPolys {
+module.exports = class OutlookPolys {
   constructor (outlook, place) {
-    const polys = []
+    this.polys = []
     const lookup = [[1, 1, 1, 1], [1, 1, 2, 2], [2, 2, 3, 3], [2, 3, 3, 4]]
 
     const locationCoords = turf.polygon([[
@@ -13,85 +13,67 @@ class OutlookPolys {
       [place.bbox2k[0], place.bbox2k[1]]
     ]])
 
-    outlook.risk_areas.forEach(riskArea => {
-      riskArea.risk_area_blocks.forEach(riskAreaBlock => {
-        riskAreaBlock.polys.forEach(poly => {
+    for (const riskArea of outlook.risk_areas) {
+      for (const riskAreaBlock of riskArea.risk_area_blocks) {
+        for (const poly of riskAreaBlock.polys) {
+          let polyCoords
           // if linestring ( i.e. coastal ) add buffer and change geometry for use with turf
           if (poly.poly_type === 'coastal') {
-            const feature = {
+            polyCoords = turf.polygon(turf.buffer({
               type: 'Feature',
               properties: { polyType: 'coastal' },
               geometry: {
                 type: 'LineString',
                 coordinates: poly.coordinates
               }
-            }
-
-            const buffer = turf.buffer(feature, 1, { units: 'miles' })
-            const coordinates = buffer.geometry.coordinates
-            feature.geometry.type = 'Polygon'
-            feature.geometry.coordinates = coordinates
-            poly.coordinates = coordinates
+            }, 1, { units: 'miles' }).geometry.coordinates)
+          } else {
+            polyCoords = turf.polygon(poly.coordinates)
           }
 
-          // test if poly intersects
-          const polyCoords = turf.polygon(poly.coordinates)
-
-          const intersection = turf.intersect(polyCoords, locationCoords)
-
           // build array of polys that intersect
-          if (intersection) {
-            const riskLevels = riskAreaBlock.risk_levels
-
-            riskAreaBlock.days.forEach(day => {
-              Object.keys(riskLevels).forEach(key => {
-                const impact = riskLevels[key][0]
-                const likelihood = riskLevels[key][1]
+          if (turf.intersect(polyCoords, locationCoords)) {
+            for (const day of riskAreaBlock.days) {
+              for (const [key, [impact, likelihood]] of Object.entries(riskAreaBlock.risk_levels)) {
                 const riskLevel = lookup[impact - 1][likelihood - 1]
-                const polyId = poly.id
-
                 if (impact > 1 && !(impact === 2 && likelihood === 1)) {
-                  polys.push({
+                  this.polys.push({
                     riskLevel,
                     impact,
                     likelihood,
                     day,
-                    polyId,
+                    polyId: poly.id,
                     source: key,
                     messageId: `${riskLevel}-i${impact}-l${likelihood}`
                   })
                 }
-              })
-            })
+              }
+            }
           }
-        })
-      })
-    })
-
-    // Sort array of polygons that intersect with the location bounding box by:
-    // day if day is the same by messageId if messageId is the same by source
-
-    polys.sort((a, b) => {
-      if (a.day !== b.day) {
-        return a.day < b.day
-          ? -1
-          : 1
+        }
       }
-      if (a.messageId !== b.messageId) {
-        return a.messageId > b.messageId
-          ? -1
-          : 1
-      }
-      const r = a.source < b.source
-        ? 1
-        : 0
-      return a.source > b.source
-        ? -1
-        : r
-    })
-
-    this.polys = polys
+    }
+    this.polys.sort(sortPolys)
   }
 }
 
-module.exports = OutlookPolys
+// Sort array of polygons that intersect with the location bounding box by:
+// day if day is the same by messageId if messageId is the same by source
+function sortPolys (a, b) {
+  if (a.day !== b.day) {
+    return a.day < b.day
+      ? -1
+      : 1
+  }
+  if (a.messageId !== b.messageId) {
+    return a.messageId > b.messageId
+      ? -1
+      : 1
+  }
+  if (a.source > b.source) {
+    return -1
+  }
+  return a.source < b.source
+    ? 1
+    : 0
+}

--- a/server/models/outlook-polys.js
+++ b/server/models/outlook-polys.js
@@ -1,9 +1,14 @@
 const turf = require('@turf/turf')
 
+const RISK_LEVELS = new Map([
+  [1, new Map([[1, 1], [2, 1], [3, 1], [4, 1]])],
+  [2, new Map([[1, 1], [2, 1], [3, 2], [4, 2]])],
+  [3, new Map([[1, 2], [2, 2], [3, 3], [4, 3]])],
+  [4, new Map([[1, 2], [2, 3], [3, 4], [4, 4]])]
+])
 module.exports = class OutlookPolys {
   constructor (outlook, place) {
     this.polys = []
-    const lookup = [[1, 1, 1, 1], [1, 1, 2, 2], [2, 2, 3, 3], [2, 3, 3, 4]]
 
     const locationCoords = turf.polygon([[
       [place.bbox2k[0], place.bbox2k[1]],
@@ -23,8 +28,8 @@ module.exports = class OutlookPolys {
 
           for (const day of riskAreaBlock.days) {
             for (const [key, [impact, likelihood]] of Object.entries(riskAreaBlock.risk_levels)) {
-              const riskLevel = lookup[impact - 1][likelihood - 1]
               if (impact > 1 && !(impact === 2 && likelihood === 1)) {
+                const riskLevel = RISK_LEVELS.get(impact).get(likelihood)
                 this.polys.push({
                   riskLevel,
                   impact,


### PR DESCRIPTION
## What
This PR refactors the outlook-polys model to be more memory efficient:
- refactors usage of `Array.forEach()` to `for ... of` loops ([see link](https://leanylabs.com/blog/js-forEach-map-reduce-vs-for-for_of/#arrayforeach-vs-for-and-forof))
- removes interstitial variables in loops where possible
- extracts sort function

## Why
We were facing a gnarly issue on load tests, where for some reason the `@turf/library` would fail when under load, though calling the library with the same variables when not under load or locally would not replicate the error. Similar errors had been seen on developer laptops which were running low on resources. 

So as a bit of a "hail-mary" commit I refactored this model in the hope that it would resolve this issue and unblock the next release. Having re-run the load test it appears to have worked, though I have no idea exactly why.

### NOTE
This PR *WILL* fail Sonarcloud with code smells due to the fact we nest 6 for loops and some conditionals (the existing code also failed). This cannot be resolved without either:
- eliminating the performance gains this PR is aimed at achieving
- significant refactoring of flood-app's use of the outlook to cache some of this processed data, eliminating the need to be so performant 

As this PR is attempting to unblock a release, I don't think the latter option is worthwhile at this time and the first is redundant.