### PR TITLE
FSR-1134 | SEO improvements - return 404 for unknown locations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "pino": "^8.16.2",
         "pino-abstract-transport": "^1.1.0",
         "pino-pretty": "^10.2.3",
+        "qs": "^6.12.1",
         "regenerator-runtime": "^0.14.0",
         "sass": "^1.69.5",
         "sinon": "^17.0.1",
@@ -9692,6 +9693,20 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
+      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/querystring": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "pino": "^8.16.2",
     "pino-abstract-transport": "^1.1.0",
     "pino-pretty": "^10.2.3",
+    "qs": "^6.12.1",
     "regenerator-runtime": "^0.14.0",
     "sass": "^1.69.5",
     "sinon": "^17.0.1",

--- a/server/routes/lib/utils.js
+++ b/server/routes/lib/utils.js
@@ -1,0 +1,7 @@
+function slugify (text = '') {
+  return text.replace(/,/g, '').replace(/ /g, '-').toLowerCase()
+}
+
+module.exports = {
+  slugify
+}

--- a/server/routes/location.js
+++ b/server/routes/location.js
@@ -1,75 +1,83 @@
 const joi = require('@hapi/joi')
+const boom = require('@hapi/boom')
 const ViewModel = require('../models/views/location')
 const OutlookTabsModel = require('../models/outlook-tabs')
 const locationService = require('../services/location')
 const formatDate = require('../util').formatDate
 const moment = require('moment-timezone')
 const tz = 'Europe/London'
+const { slugify } = require('./lib/utils')
 
-module.exports = {
-  method: 'GET',
-  path: '/location',
-  handler: async (request, h) => {
-    const location = request.query.q || request.query.location
+async function routeHandler (request, h) {
+  const { location } = request.params
+  if (location.match(/^england$/i)) {
+    return h.redirect('/')
+  }
 
-    if (location.match(/^england$/i)) {
-      return h.redirect('/')
-    }
+  const [place] = await locationService.find(location)
 
-    const [place] = await locationService.find(location)
+  if (slugify(place?.name) !== location) {
+    return boom.notFound(`Location ${location} not found`)
+  }
 
-    if (!place?.name) {
-      return h.view('location-not-found', { pageTitle: 'Error: Find location - Check for flooding', location })
-    }
+  if (!place.isEngland.is_england) {
+    request.logger.warn({
+      situation: 'Location search error: Valid response but location not in England.'
+    })
+    return h.view('location-not-found', { pageTitle: 'Error: Find location - Check for flooding', location })
+  }
 
-    if (!place.isEngland.is_england) {
-      request.logger.warn({
-        situation: 'Location search error: Valid response but location not in England.'
-      })
-      return h.view('location-not-found', { pageTitle: 'Error: Find location - Check for flooding', location })
-    }
+  const { tabs, outOfDate, dataError } = await createOutlookTabs(place, request)
 
-    const { tabs, outOfDate, dataError } = await createOutlookTabs(place, request)
+  const [
+    impacts,
+    { floods },
+    stations
+  ] = await Promise.all([
+    request.server.methods.flood.getImpactsWithin(place.bbox2k),
+    request.server.methods.flood.getFloodsWithin(place.bbox2k),
+    request.server.methods.flood.getStationsWithin(place.bbox10k)
+  ])
+  const model = new ViewModel({ location, place, floods, stations, impacts, tabs, outOfDate, dataError })
+  return h.view('location', { model })
+}
 
-    const [
-      impacts,
-      { floods },
-      stations
-    ] = await Promise.all([
-      request.server.methods.flood.getImpactsWithin(place.bbox2k),
-      request.server.methods.flood.getFloodsWithin(place.bbox2k),
-      request.server.methods.flood.getStationsWithin(place.bbox10k)
-    ])
-    const model = new ViewModel({ location, place, floods, stations, impacts, tabs, outOfDate, dataError })
-    return h.view('location', { model })
-  },
-  options: {
-    validate: {
-      query: joi.object({
-        q: joi.string(),
-        location: joi.string(),
-        cz: joi.string(),
-        l: joi.string(),
-        btn: joi.string(),
-        ext: joi.string(),
-        fid: joi.string(),
-        lyr: joi.string(),
-        v: joi.string()
-      }).or('q', 'location'), // q or location must be present in request.query
-      failAction: (request, h) => {
-        request.logger.warn({
-          situation: 'Location search error: Invalid or no string input.'
-        })
-        const location = request.query.q || request.query.location
-        if (!location) {
-          return h.redirect('/').takeover()
-        } else {
-          return h.view('location-not-found', { pageTitle: 'Error: Find location - Check for flooding', location }).takeover()
-        }
-      }
-    }
+const failActionHandler = (request, h) => {
+  request.logger.warn({
+    situation: 'Location search error: Invalid or no string input.'
+  })
+  const location = request.query.q || request.query.location
+  if (!location) {
+    return h.redirect('/').takeover()
+  } else {
+    return h.view('location-not-found', { pageTitle: 'Error: Find location - Check for flooding', location }).takeover()
   }
 }
+
+const queryValidation = {
+  cz: joi.string(),
+  l: joi.string(),
+  btn: joi.string(),
+  ext: joi.string(),
+  fid: joi.string(),
+  lyr: joi.string(),
+  v: joi.string()
+}
+
+module.exports = [{
+  method: 'GET',
+  path: '/location/{location}',
+  handler: routeHandler,
+  options: {
+    validate: {
+      params: joi.object({
+        location: joi.string().lowercase()
+      }),
+      query: joi.object(queryValidation),
+      failAction: failActionHandler
+    }
+  }
+}]
 
 const createOutlookTabs = async (place, request) => {
   let tabs = {}

--- a/server/routes/location.js
+++ b/server/routes/location.js
@@ -10,7 +10,7 @@ const { slugify } = require('./lib/utils')
 const qs = require('qs')
 
 function createQueryParametersString (queryObject) {
-  const { q: _, ...otherParameters } = queryObject
+  const { q, ...otherParameters } = queryObject
   // otherParameters has all parameters except q
   const queryString = qs.stringify(otherParameters, { addQueryPrefix: true, encode: false })
   return queryString

--- a/server/routes/location.js
+++ b/server/routes/location.js
@@ -23,7 +23,7 @@ async function legacyRouteHandler (request, h) {
   if (place) {
     return h.redirect(`/location/${slugify(place?.name)}${queryString}`).permanent()
   }
-  return h.view('location-not-found', { pageTitle: 'Error: Find location - Check for flooding', location })
+  return boom.notFound(`Location ${location} not found`)
 }
 
 async function routeHandler (request, h) {
@@ -42,7 +42,7 @@ async function routeHandler (request, h) {
     request.logger.warn({
       situation: 'Location search error: Valid response but location not in England.'
     })
-    return h.view('location-not-found', { pageTitle: 'Error: Find location - Check for flooding', location })
+    return boom.notFound(`Location ${location} not found`)
   }
 
   const { tabs, outOfDate, dataError } = await createOutlookTabs(place, request)

--- a/server/routes/national.js
+++ b/server/routes/national.js
@@ -2,6 +2,8 @@ const joi = require('@hapi/joi')
 const OutlookModel = require('../models/outlook')
 const FloodsModel = require('../models/floods')
 const ViewModel = require('../models/views/national')
+const locationService = require('../services/location')
+const { slugify } = require('./lib/utils')
 
 async function getModel (request, location) {
   const floods = new FloodsModel(await request.server.methods.flood.getFloods())
@@ -39,7 +41,11 @@ module.exports = [
         const model = await getModel(request, location)
         return h.view('national', { model })
       }
-      return h.redirect(`/location?q=${encodeURIComponent(location)}`)
+      const [place] = await locationService.find(location)
+      if (!place?.name) {
+        return h.view('location-not-found', { pageTitle: 'Error: Find location - Check for flooding', location })
+      }
+      return h.redirect(`/location/${encodeURIComponent(slugify(place?.name))}`)
     },
     options: {
       validate: {

--- a/server/routes/national.js
+++ b/server/routes/national.js
@@ -42,7 +42,7 @@ module.exports = [
         return h.view('national', { model })
       }
       const [place] = await locationService.find(location)
-      if (!place?.name) {
+      if (!place?.name || !place.isEngland.is_england) {
         return h.view('location-not-found', { pageTitle: 'Error: Find location - Check for flooding', location })
       }
       return h.redirect(`/location/${encodeURIComponent(slugify(place?.name))}`)

--- a/test/lib/flush-app-require-cache.js
+++ b/test/lib/flush-app-require-cache.js
@@ -1,0 +1,19 @@
+function flushAppRequireCache () {
+  // This is a bit hacky but needed when stubbing dependancies of dependancies
+  // an example would be the config module where it is a dependancy of a model
+  // which is a dependancy of a route
+  //
+  // There are almost certainly better ways of structuring the codebase and
+  // writing the tests to remove the need to do this
+  Object.keys(require.cache)
+    // We only want to remove local modules otherwise stuff breaks
+    .filter(key => !key.includes('node_modules'))
+    // We only want to remove local modules in the dependency chain described above
+    // otherwise some of the tests fail for obscure reasons (e.g. instanceOf fails
+    // to recognise a locally defined existing type such as LocationSearchError)
+    // the 3 types in the regex are the minimum to get all tests passing
+    .filter(key => /(model|route|service)/.test(key))
+    .forEach(key => { delete require.cache[key] })
+}
+
+module.exports = flushAppRequireCache

--- a/test/routes/location.js
+++ b/test/routes/location.js
@@ -96,8 +96,8 @@ lab.experiment('Routes test - location - 2', () => {
       url: '/location'
     }
     const response = await server.inject(options)
-    Code.expect(response.statusCode).to.equal(404)
-    Code.expect(response.payload).to.contain('Page not found')
+    Code.expect(response.statusCode).to.equal(302)
+    Code.expect(response.headers.location).to.equal('/')
   })
   lab.test('GET /location with query parameters giving undefined location', async () => {
     const fakeGetJson = () => {
@@ -484,7 +484,8 @@ lab.experiment('Routes test - location - 2', () => {
 
     const response = await server.inject(options)
 
-    Code.expect(response.statusCode).to.equal(404)
+    Code.expect(response.statusCode).to.equal(302)
+    Code.expect(response.headers.location).to.equal('/')
   })
   lab.test('GET /location with query parameters check for 1 alert 1 nlif', async () => {
     const floodService = require('../../server/services/flood')

--- a/test/routes/location.js
+++ b/test/routes/location.js
@@ -190,11 +190,11 @@ lab.experiment('Routes test - location - 2', () => {
 
     const options = {
       method: 'GET',
-      url: '/location?q=coxwold'
+      url: '/location?q=coxwold&lyr=mv,ts,tw,ta'
     }
     const response = await server.inject(options)
     Code.expect(response.statusCode).to.equal(301)
-    Code.expect(response.headers.location).to.equal('/location/coxwold-north-yorkshire')
+    Code.expect(response.headers.location).to.equal('/location/coxwold-north-yorkshire?lyr=mv,ts,tw,ta')
   })
   lab.test('GET /location with no query parameters', async () => {
     const locationPlugin = {

--- a/test/routes/location.js
+++ b/test/routes/location.js
@@ -81,6 +81,9 @@ lab.experiment('Routes test - location - 2', () => {
     }
 
     await server.register(require('../../server/plugins/logging'))
+    await server.register(require('../../server/plugins/views'))
+    await server.register(require('../../server/plugins/session'))
+    await server.register(require('../../server/plugins/error-pages'))
     await server.register(locationPlugin)
     // Add Cache methods to server
     const registerServerMethods = require('../../server/services/server-methods')
@@ -93,8 +96,8 @@ lab.experiment('Routes test - location - 2', () => {
       url: '/location'
     }
     const response = await server.inject(options)
-    Code.expect(response.headers.location).to.equal('/')
-    Code.expect(response.payload).to.equal('')
+    Code.expect(response.statusCode).to.equal(404)
+    Code.expect(response.payload).to.contain('Page not found')
   })
   lab.test('GET /location with query parameters giving undefined location', async () => {
     const fakeGetJson = () => {
@@ -129,6 +132,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.register(require('../../server/plugins/views'))
     await server.register(require('../../server/plugins/session'))
     await server.register(require('../../server/plugins/logging'))
+    await server.register(require('../../server/plugins/error-pages'))
     await server.register(locationPlugin)
     // Add Cache methods to server
     const registerServerMethods = require('../../server/services/server-methods')
@@ -137,12 +141,12 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=xxxxxx'
+      url: '/location/xxxxxx'
     }
 
     const response = await server.inject(options)
-    Code.expect(response.statusCode).to.equal(200)
-    Code.expect(response.payload).to.contain('We couldn\'t find')
+    Code.expect(response.statusCode).to.equal(404)
+    Code.expect(response.payload).to.contain('Page not found')
   })
   lab.test('GET /location with query parameters giving undefined location parameter set as location', async () => {
     const fakeGetJson = () => {
@@ -177,6 +181,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.register(require('../../server/plugins/views'))
     await server.register(require('../../server/plugins/session'))
     await server.register(require('../../server/plugins/logging'))
+    await server.register(require('../../server/plugins/error-pages'))
     await server.register(locationPlugin)
     // Add Cache methods to server
     const registerServerMethods = require('../../server/services/server-methods')
@@ -185,12 +190,12 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?location=xxxxxx'
+      url: '/location/xxxxxx'
     }
 
     const response = await server.inject(options)
-    Code.expect(response.statusCode).to.equal(200)
-    Code.expect(response.payload).to.contain('We couldn\'t find')
+    Code.expect(response.statusCode).to.equal(404)
+    Code.expect(response.payload).to.contain('Page not found')
   })
   lab.experiment('GET /location with rejected query', () => {
     lab.beforeEach(async () => {
@@ -211,52 +216,38 @@ lab.experiment('Routes test - location - 2', () => {
     lab.test('returns not found page when entering Wales', async () => {
       const options = {
         method: 'GET',
-        url: '/location?q=Wales'
+        url: '/location/Wales'
       }
 
       const response = await server.inject(options)
-      Code.expect(response.statusCode).to.equal(200)
-      const root = parse(response.payload)
-      const h1 = root.querySelector('h1.govuk-heading-xl')
-      Code.expect(h1.text).to.contain("We couldn't find 'Wales', England")
+      Code.expect(response.statusCode).to.equal(404)
     })
     lab.test('returns not found page when entering Scotland', async () => {
       const options = {
         method: 'GET',
-        url: '/location?q=Scotland'
+        url: '/location/Scotland'
       }
 
       const response = await server.inject(options)
-      Code.expect(response.statusCode).to.equal(200)
-      const root = parse(response.payload)
-      const h1 = root.querySelector('h1.govuk-heading-xl')
-      Code.expect(h1.text).to.contain("We couldn't find 'Scotland', England")
+      Code.expect(response.statusCode).to.equal(404)
     })
     lab.test('returns not found page when entering non-alphanumeric only search', async () => {
       const options = {
         method: 'GET',
-        url: '/location?q=%%%'
+        url: '/location/,-+'
       }
 
       const response = await server.inject(options)
-      Code.expect(response.statusCode).to.equal(200)
-
-      const root = parse(response.payload)
-      const h1 = root.querySelector('h1.govuk-heading-xl')
-      Code.expect(h1.text).to.contain("We couldn't find '%%%', England")
+      Code.expect(response.statusCode).to.equal(404)
     })
     lab.test('returns not found page when entering a query containing angle brackets', async () => {
       const options = {
         method: 'GET',
-        url: '/location?q=<script>'
+        url: '/location/<script>'
       }
 
       const response = await server.inject(options)
-      Code.expect(response.statusCode).to.equal(200)
-
-      const root = parse(response.payload)
-      const h1 = root.querySelector('h1.govuk-heading-xl')
-      Code.expect(h1.text).to.contain("We couldn't find '<script>', England")
+      Code.expect(response.statusCode).to.equal(404)
     })
   })
   lab.experiment('GET /location with query parameters giving defined location', () => {
@@ -278,7 +269,7 @@ lab.experiment('Routes test - location - 2', () => {
     lab.test('response should be 200', async () => {
       const options = {
         method: 'GET',
-        url: '/location?q=Warrington'
+        url: '/location/Warrington'
       }
 
       const response = await server.inject(options)
@@ -287,7 +278,7 @@ lab.experiment('Routes test - location - 2', () => {
     lab.test('river levels link should use location query', async () => {
       const options = {
         method: 'GET',
-        url: '/location?q=Warrington'
+        url: '/location/Warrington'
       }
 
       const response = await server.inject(options)
@@ -344,7 +335,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=Warrington&fbclid=*()*()*890890890'
+      url: '/location/Warrington?fbclid=*()*()*890890890'
     }
 
     const response = await server.inject(options)
@@ -395,7 +386,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?location=Warrington'
+      url: '/location/Warrington'
     }
 
     const response = await server.inject(options)
@@ -446,12 +437,11 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=Warrington'
+      url: '/location/Warrington'
     }
 
     const response = await server.inject(options)
 
-    Code.expect(response.payload).to.contain('There are no flood warnings or alerts in this area.')
     Code.expect(response.statusCode).to.equal(200)
     Code.expect(response.payload).not.to.match(/<div class="defra-related-items">[\s\S]*?<a class="govuk-link" href="https:\/\/www\.gov\.uk\/sign-up-for-flood-warnings">\s*Get flood warnings by phone, text or email\s*<\/a>/)
     Code.expect(response.payload).to.match(/<div class="defra-related-items">[\s\S]*?<a class="govuk-link" href="https:\/\/www\.gov\.uk\/prepare-for-flooding">\s*Prepare for flooding\s*<\/a>/)
@@ -459,6 +449,7 @@ lab.experiment('Routes test - location - 2', () => {
     Code.expect(response.payload).to.match(/<div class="defra-related-items">[\s\S]*?<a class="govuk-link" href="https:\/\/www\.gov\.uk\/after-flood">\s*What to do after a flood\s*<\/a>/)
     Code.expect(response.payload).not.to.match(/<div class="defra-related-items">[\s\S]*?<a class="govuk-link" href="https:\/\/www\.gov\.uk\/check-long-term-flood-risk">\s*Check your long term flood risk\s*<\/a>/)
     Code.expect(response.payload).to.match(/<div class="defra-related-items">[\s\S]*?<a class="govuk-link" href="https:\/\/www\.gov\.uk\/report-flood-cause">\s*Report a flood\s*<\/a>/)
+    Code.expect(response.payload).to.contain('There are no flood warnings or alerts in this area.')
   })
   lab.test('GET /location with no query', async () => {
     const fakeGetJson = () => {
@@ -493,8 +484,7 @@ lab.experiment('Routes test - location - 2', () => {
 
     const response = await server.inject(options)
 
-    Code.expect(response.statusCode).to.equal(302)
-    Code.expect(response.headers.location).to.equal('/')
+    Code.expect(response.statusCode).to.equal(404)
   })
   lab.test('GET /location with query parameters check for 1 alert 1 nlif', async () => {
     const floodService = require('../../server/services/flood')
@@ -576,7 +566,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=Warrington'
+      url: '/location/Warrington'
     }
 
     const response = await server.inject(options)
@@ -718,7 +708,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=coxwold'
+      url: '/location/coxwold-north-yorkshire'
     }
 
     const response = await server.inject(options)
@@ -807,7 +797,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=Warrington'
+      url: '/location/Warrington'
     }
 
     const response = await server.inject(options)
@@ -886,7 +876,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=Warrington'
+      url: '/location/Warrington'
     }
 
     const response = await server.inject(options)
@@ -937,13 +927,12 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=Warrington'
+      url: '/location/Warrington'
     }
 
     const response = await server.inject(options)
 
-    Code.expect(response.statusCode).to.equal(200)
-    Code.expect(response.payload).to.contain('We couldn\'t find')
+    Code.expect(response.statusCode).to.equal(404)
   })
   lab.test('GET /location with query parameters for location-1sw-2w-1a', async () => {
     const floodService = require('../../server/services/flood')
@@ -987,7 +976,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=Warrington'
+      url: '/location/Warrington'
     }
 
     const response = await server.inject(options)
@@ -1125,7 +1114,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=Warrington'
+      url: '/location/Warrington'
     }
 
     const response = await server.inject(options)
@@ -1215,7 +1204,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=Warrington'
+      url: '/location/Warrington'
     }
 
     const response = await server.inject(options)
@@ -1268,7 +1257,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=Warrington'
+      url: '/location/Warrington'
     }
 
     const response = await server.inject(options)
@@ -1358,7 +1347,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=Warrington'
+      url: '/location/Warrington'
     }
 
     const response = await server.inject(options)
@@ -1405,7 +1394,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=England'
+      url: '/location/England'
     }
 
     const response = await server.inject(options)
@@ -1507,7 +1496,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=Warrington'
+      url: '/location/Warrington'
     }
 
     const response = await server.inject(options)
@@ -1564,7 +1553,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=Warrington'
+      url: '/location/Warrington'
     }
 
     const response = await server.inject(options)
@@ -1621,7 +1610,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=Warrington'
+      url: '/location/Warrington'
     }
 
     const response = await server.inject(options)
@@ -1678,7 +1667,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=Warrington'
+      url: '/location/Warrington'
     }
 
     const response = await server.inject(options)
@@ -1755,7 +1744,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=Warrington'
+      url: '/location/Warrington'
     }
 
     const response = await server.inject(options)
@@ -1832,7 +1821,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=Warrington'
+      url: '/location/Warrington'
     }
 
     const response = await server.inject(options)
@@ -1869,7 +1858,7 @@ lab.experiment('Routes test - location - 2', () => {
     await server.initialize()
     const options = {
       method: 'GET',
-      url: '/location?q=liverpool'
+      url: '/location/liverpool'
     }
 
     const response = await server.inject(options)

--- a/test/routes/location.js
+++ b/test/routes/location.js
@@ -70,6 +70,132 @@ lab.experiment('Routes test - location - 2', () => {
     await server.stop()
     await sandbox.restore()
   })
+  lab.test('GET /location with legacy query parameters with no results', async () => {
+    const fakeGetJson = () => {
+      return {
+        authenticationResultCode: 'ValidCredentials',
+        brandLogoUri: 'http://dev.virtualearth.net/Branding/logo_powered_by.png',
+        copyright: 'Copyright',
+        resourceSets: [
+          {
+            estimatedTotal: 0,
+            resources: []
+          }
+        ],
+        statusCode: 200,
+        tatusDescription: 'OK',
+        traceId: 'trace-id'
+      }
+    }
+
+    const util = require('../../server/util')
+    sandbox.stub(util, 'getJson').callsFake(fakeGetJson)
+
+    const locationPlugin = {
+      plugin: {
+        name: 'location',
+        register: (server, options) => {
+          server.route(require('../../server/routes/location'))
+        }
+      }
+    }
+
+    await server.register(require('../../server/plugins/logging'))
+    await server.register(require('../../server/plugins/views'))
+    await server.register(require('../../server/plugins/session'))
+    await server.register(require('../../server/plugins/error-pages'))
+    await server.register(locationPlugin)
+    // Add Cache methods to server
+    const registerServerMethods = require('../../server/services/server-methods')
+    registerServerMethods(server)
+
+    await server.initialize()
+
+    const options = {
+      method: 'GET',
+      url: '/location?q=fkfflsdfk'
+    }
+    const response = await server.inject(options)
+    Code.expect(response.statusCode).to.equal(404)
+  })
+  lab.test('GET /location with legacy query parameters', async () => {
+    const fakeGetJson = () => {
+      return {
+        authenticationResultCode: 'ValidCredentials',
+        brandLogoUri: 'http://dev.virtualearth.net/Branding/logo_powered_by.png',
+        copyright: 'Copyright',
+        resourceSets: [
+          {
+            estimatedTotal: 1,
+            resources: [
+              {
+                __type: 'Location:http://schemas.microsoft.com/search/local/ws/rest/v1',
+                bbox: [54.18498992919922, -1.1886399984359741, 54.1898307800293, -1.1779199838638306],
+                name: 'Coxwold, North Yorkshire',
+                point: {
+                  type: 'Point',
+                  coordinates: [54.187835693359375, -1.182824969291687]
+                },
+                address: {
+                  adminDistrict: 'England',
+                  adminDistrict2: 'North Yorkshire',
+                  countryRegion: 'United Kingdom',
+                  formattedAddress: 'Coxwold, North Yorkshire',
+                  locality: 'Coxwold',
+                  countryRegionIso2: 'GB'
+                },
+                confidence: 'High',
+                entityType: 'PopulatedPlace',
+                geocodePoints: [
+                  {
+                    type: 'Point',
+                    coordinates: [54.187835693359375, -1.182824969291687],
+                    calculationMethod: 'Rooftop',
+                    usageTypes: ['Display']
+                  }
+                ],
+                matchCodes: ['Good']
+              }
+            ]
+          }
+        ],
+        statusCode: 200,
+        tatusDescription: 'OK',
+        traceId: 'trace-id'
+      }
+    }
+
+    const util = require('../../server/util')
+    sandbox.stub(util, 'getJson').callsFake(fakeGetJson)
+
+    const locationPlugin = {
+      plugin: {
+        name: 'location',
+        register: (server, options) => {
+          server.route(require('../../server/routes/location'))
+        }
+      }
+    }
+
+    await server.register(require('../../server/plugins/logging'))
+    await server.register(require('../../server/plugins/views'))
+    await server.register(require('../../server/plugins/session'))
+    await server.register(require('../../server/plugins/error-pages'))
+    await server.register(locationPlugin)
+    // Add Cache methods to server
+    const registerServerMethods = require('../../server/services/server-methods')
+    registerServerMethods(server)
+
+    await server.initialize()
+
+    const options = {
+      method: 'GET',
+      url: '/location?q=coxwold'
+    }
+    const response = await server.inject(options)
+    Code.expect(response.statusCode).to.equal(301)
+    Code.expect(response.headers.location).to.equal('/location/coxwold-north-yorkshire')
+  })
   lab.test('GET /location with no query parameters', async () => {
     const locationPlugin = {
       plugin: {


### PR DESCRIPTION
- https://eaflood.atlassian.net/browse/FSR-1134
- Handle unknown locations in an SEO friendly way
- Check for location found in post of national page
  - Use geographically qualified name as pseudo-id in the redirect to the location page if a matching location is found
  - If no matching location is returned from Bing then display message to that effect 
