### PR TITLE
FSR-596 | Fix "Removed message" bug (FSR-1191), refactor tests and improve coverage

### DIFF
--- a/server/models/views/target-area.js
+++ b/server/models/views/target-area.js
@@ -49,7 +49,8 @@ class ViewModel {
     let situationChanged = flood
       ? `Updated ${timeSituationChanged} on ${dateSituationChanged}`
       : `Up to date as of ${timeSituationChanged} on ${dateSituationChanged}`
-    if (flood && flood?.severityLevel?.id === 4) {
+
+    if (severityLevel?.id === 4) {
       situationChanged = `Removed ${timeSituationChanged} on ${dateSituationChanged}`
     }
 

--- a/server/models/views/target-area.js
+++ b/server/models/views/target-area.js
@@ -44,6 +44,7 @@ class ViewModel {
     area.description = area.description.trim()
     const description = area.description.endsWith('.') ? area.description.slice(0, -1) : area.description
     const areaDescription = `Flood ${type} area: ${description}.`
+    const metaDescription = `Flooding information and advice for the area: ${description}.`
 
     const parentAreaAlert = (!!(((flood && severityLevel.id === 4) && (type === 'warning')) || !flood) && (parentSeverityLevel?.isActive))
     let situationChanged = flood
@@ -55,7 +56,6 @@ class ViewModel {
     }
 
     const pageTitle = (severityLevel?.isActive ? `${severityLevel.title} for ${area.name}` : `${area.name} flood ${type} area`)
-    const metaDescription = `Flooding information and advice for the area: ${area.description}.`
     const metaCanonical = `/target-area/${area.code}`
 
     Object.assign(this, {

--- a/test/lib/helpers/data-builders.js
+++ b/test/lib/helpers/data-builders.js
@@ -1,0 +1,64 @@
+const Joi = require('joi')
+
+const warningBaseSchema = Joi.object({
+  ta_id: Joi.number().integer().default(1),
+  ta_code: Joi.string(),
+  ta_name: Joi.string().default('TA #1'),
+  ta_description: Joi.string().default('Description for TA'),
+  situation: Joi.string().default('Danger flood possible/likely'),
+  situation_changed: Joi.string().default('2024-04-23T07:57:00.000Z'),
+  severity_value: Joi.number().integer(),
+  severity: Joi.string()
+})
+
+const targetAreaSchema = Joi.object({
+  id: Joi.number().integer().default(1),
+  area: Joi.string().default('Area #1'),
+  name: Joi.string().default('TA #1'),
+  code: Joi.string(),
+  description: Joi.string().default('Description for TA'),
+  parent: Joi.string(),
+  centroid: Joi.string().default('{"type":"Point","coordinates":[-3.590072619,54.550316408]}')
+})
+
+function validateAgainstSchema (schema, values) {
+  const { error, value } = schema.validate(values)
+
+  if (error) {
+    throw new Error(error)
+  }
+
+  return value
+}
+
+function getWarning (values) {
+  return validateAgainstSchema(
+    warningBaseSchema,
+    { severity_value: 2, severity: 'Flood warning', ...values }
+  )
+}
+
+function getAlert (values) {
+  return validateAgainstSchema(
+    warningBaseSchema,
+    { severity_value: 1, severity: 'Flood alert', ...values }
+  )
+}
+
+function getRemoved (values) {
+  return validateAgainstSchema(
+    warningBaseSchema,
+    { severity_value: 4, severity: 'Flood warning removed', ...values }
+  )
+}
+
+function getTargetArea (values) {
+  return validateAgainstSchema(targetAreaSchema, values)
+}
+
+module.exports = {
+  getAlert,
+  getWarning,
+  getRemoved,
+  getTargetArea
+}

--- a/test/lib/helpers/html-expectations.js
+++ b/test/lib/helpers/html-expectations.js
@@ -1,30 +1,44 @@
 const { expect } = require('@hapi/code')
 
+function errorMessage (text) {
+  return `${text}\n(Call stack: ${new Error().stack})`
+}
+
 // Checks if an anchor with specific text and URL exists among provided anchors
 function linkChecker (anchors, targetText, url) {
-  if (targetText === 'Check your long term flood risk') {
-    const anchor = anchors.find(a => a.text.trim() === targetText)
-    expect(anchor, `Anchor ${targetText} not found`).to.exist()
+  const anchor = anchors.find(a => a.text.trim() === targetText)
+  expect(anchor, errorMessage(`Anchor ${targetText} not found`)).to.exist()
+  // This conditional is here as there are some tests which do not pass in a value for
+  // url as it comes from an env var which may change depending on the environment.
+  // Once all tests stub out the value of any url rather than take it from env vars
+  // then a url should always be passed in and the conditional should not be needed
+  if (url) {
+    expect(anchor.getAttribute('href'), errorMessage(`Anchor ${targetText} doesn't contain expected URL (${url})`)).to.equal(url)
   } else {
-    const anchor = anchors.find(a => a.text.trim() === targetText)
-    expect(anchor, `Anchor ${targetText} not found`).to.exist()
-    expect(anchor.getAttribute('href'), `Anchor ${targetText} doesn't contain expected URL (${url})`).to.equal(url)
+    expect(anchor.getAttribute('href'), errorMessage(`Anchor ${targetText} doesn't contain a URL`)).to.not.be.undefined()
   }
 }
 
 //  Verifies that the page contains expected related content links
-function fullRelatedContentChecker (root) {
+function fullRelatedContentChecker (root, cyltfrLink) {
   const relatedContentLinks = root.querySelectorAll('.defra-related-items a')
   expect(relatedContentLinks.length, 'Should be 6 related content links').to.equal(6)
   linkChecker(relatedContentLinks, 'Get flood warnings by phone, text or email', 'https://www.gov.uk/sign-up-for-flood-warnings')
   linkChecker(relatedContentLinks, 'Prepare for flooding', 'https://www.gov.uk/prepare-for-flooding')
   linkChecker(relatedContentLinks, 'What to do before or during a flood', 'https://www.gov.uk/guidance/flood-alerts-and-warnings-what-they-are-and-what-to-do')
   linkChecker(relatedContentLinks, 'What to do after a flood', 'https://www.gov.uk/after-flood')
-  linkChecker(relatedContentLinks, 'Check your long term flood risk')
+  linkChecker(relatedContentLinks, 'Check your long term flood risk', cyltfrLink)
   linkChecker(relatedContentLinks, 'Report a flood', 'https://www.gov.uk/report-flood-cause')
 }
 
+// Checks if a heading with specific text exists
+function headingChecker (root, headingLevel, headingText) {
+  const h1Found = root.querySelectorAll(headingLevel).some(h => h.textContent.trim() === headingText)
+  expect(h1Found, errorMessage(`Heading level ${headingLevel} with text ${headingText} not found.`)).to.be.true()
+}
+
 module.exports = {
+  headingChecker,
   linkChecker,
   fullRelatedContentChecker
 }

--- a/test/models/target-area.js
+++ b/test/models/target-area.js
@@ -6,63 +6,12 @@ const { describe, it } = exports.lab = Lab.script()
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const moment = require('moment-timezone')
-const Joi = require('joi')
-
-const warningBaseSchema = Joi.object({
-  ta_id: Joi.number().integer().default(1),
-  ta_code: Joi.string(),
-  ta_name: Joi.string().default('TA #1'),
-  ta_description: Joi.string().default('Description for TA'),
-  situation: Joi.string().default('Danger flood possible/likely'),
-  situation_changed: Joi.string().default('2024-04-23T07:57:00.000Z'),
-  severity_value: Joi.number().integer(),
-  severity: Joi.string()
-})
-
-const targetAreaSchema = Joi.object({
-  id: Joi.number().integer().default(1),
-  area: Joi.string().default('Area #1'),
-  name: Joi.string().default('TA #1'),
-  code: Joi.string(),
-  description: Joi.string().default('Description for TA'),
-  parent: Joi.string(),
-  centroid: Joi.string().default('{"type":"Point","coordinates":[-3.590072619,54.550316408]}')
-})
-
-function validateAgainstSchema (schema, values) {
-  const { error, value } = schema.validate(values)
-
-  if (error) {
-    throw new Error(error)
-  }
-
-  return value
-}
-
-function getWarning (values) {
-  return validateAgainstSchema(
-    warningBaseSchema,
-    { severity_value: 2, severity: 'Flood warning', ...values }
-  )
-}
-
-function getAlert (values) {
-  return validateAgainstSchema(
-    warningBaseSchema,
-    { severity_value: 1, severity: 'Flood alert', ...values }
-  )
-}
-
-function getRemoved (values) {
-  return validateAgainstSchema(
-    warningBaseSchema,
-    { severity_value: 4, severity: 'Flood warning removed', ...values }
-  )
-}
-
-function getTargetArea (values) {
-  return validateAgainstSchema(targetAreaSchema, values)
-}
+const {
+  getAlert,
+  getWarning,
+  getRemoved,
+  getTargetArea
+} = require('../lib/helpers/data-builders')
 
 function getTargetAreaAndWarning (targetAreaValues, floodWarningValues) {
   const area = getTargetArea(targetAreaValues)
@@ -91,6 +40,10 @@ describe('target area model test', () => {
       })
     })
     it('should remove spaces and terminate description with a single full stop', async () => {
+      // note: although this is functionally the same as
+      // require('../../server/models/views/target-area')
+      // choose to use this as proxyquire doesn't cache unlike require
+      // and therefore we don't need to flush the require cache
       const ViewModel = proxyquire('../../server/models/views/target-area', {})
       const targetAreaValues = {
         code: 'ABCDW001',

--- a/test/models/target-area.js
+++ b/test/models/target-area.js
@@ -3,7 +3,6 @@
 const Lab = require('@hapi/lab')
 const { expect } = require('@hapi/code')
 const { describe, it } = exports.lab = Lab.script()
-const fakeTargetAreaFloodData = require('../data/fakeTargetAreaFloodData.json')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const moment = require('moment-timezone')
@@ -301,31 +300,22 @@ describe('target area model test', () => {
         situationChanged: 'Updated 7:23pm on 5 August 2020'
       })
     })
-    it('??? should populate the situation changed details from the current date/time when no date in flood warning details', async () => {
-      const ViewModel = proxyquire('../../server/models/views/target-area', {
-        'moment-timezone': {
-          tz: sinon.stub().returns(moment.tz('2022-09-15T16:13:00.000Z', 'Europe/London'))
-        }
-      })
-      const { situation_changed: _, ...undatedFlood } = fakeTargetAreaFloodData.floods[0]
-      const options = {
-        area: fakeTargetAreaFloodData.area,
-        flood: undatedFlood
-      }
-      const viewModel = new ViewModel(options)
-      expect(viewModel).to.include({
-        situationChanged: 'Updated 5:13pm on 15 September 2022'
-      })
-    })
     it('should populate the situation changed with an "updated" message if flood warning no longer exists', async () => {
       const ViewModel = proxyquire('../../server/models/views/target-area', {
         'moment-timezone': {
           tz: sinon.stub().returns(moment.tz('2022-09-15T16:13:00.000Z', 'Europe/London'))
         }
       })
+      const area = getTargetArea({
+        id: 1,
+        area: 'Riverton',
+        name: 'Riverside View, Newtown',
+        code: 'ABCW001',
+        description: 'Description for Riverside View, Newtown',
+        parent: 'XYZA001'
+      })
       const options = {
-        area: fakeTargetAreaFloodData.area,
-        flood: undefined
+        area
       }
       const viewModel = new ViewModel(options)
       expect(viewModel).to.include({
@@ -338,11 +328,23 @@ describe('target area model test', () => {
           tz: sinon.stub().returns(moment.tz('2022-09-15T16:13:00.000Z', 'Europe/London'))
         }
       })
-      const flood = { ...fakeTargetAreaFloodData.floods[0] }
-      flood.severity_value = 4
+      const area = getTargetArea({
+        id: 1,
+        area: 'Riverton',
+        name: 'Riverside View, Newtown',
+        code: 'ABCW001',
+        description: 'Description for Riverside View, Newtown',
+        parent: 'XYZA001'
+      })
+      const floodWarning = getRemoved({
+        ta_id: 1,
+        ta_name: 'Riverside View, Newtown',
+        ta_code: 'ABCDW001',
+        ta_description: 'Description for Riverside View, Newtown'
+      })
       const options = {
-        area: fakeTargetAreaFloodData.area,
-        flood
+        area,
+        flood: floodWarning
       }
       const viewModel = new ViewModel(options)
       expect(viewModel).to.include({

--- a/test/models/target-area.js
+++ b/test/models/target-area.js
@@ -11,7 +11,7 @@ const Joi = require('joi')
 
 const warningBaseSchema = Joi.object({
   ta_id: Joi.number().integer().default(1),
-  ta_code: Joi.string().default('ABCDW001'),
+  ta_code: Joi.string(),
   ta_name: Joi.string().default('TA #1'),
   ta_description: Joi.string().default('Description for TA'),
   situation: Joi.string().default('Danger flood possible/likely'),
@@ -24,7 +24,7 @@ const targetAreaSchema = Joi.object({
   id: Joi.number().integer().default(1),
   area: Joi.string().default('Area #1'),
   name: Joi.string().default('TA #1'),
-  code: Joi.string().default('ABCW001'),
+  code: Joi.string(),
   description: Joi.string().default('Description for TA'),
   parent: Joi.string(),
   centroid: Joi.string().default('{"type":"Point","coordinates":[-3.590072619,54.550316408]}')

--- a/test/models/target-area.js
+++ b/test/models/target-area.js
@@ -72,6 +72,52 @@ function getTargetAreaAndWarning (targetAreaValues, floodWarningValues) {
 }
 
 describe('target area model test', () => {
+  describe('Description handling', () => {
+    it('should populate meta details', async () => {
+      const ViewModel = proxyquire('../../server/models/views/target-area', {})
+      const targetAreaValues = {
+        code: 'ABCDW001',
+        name: 'TA #1',
+        description: 'A description.'
+      }
+      const floodWarningValues = {
+        ta_code: 'ABCDW001'
+      }
+      const options = getTargetAreaAndWarning(targetAreaValues, floodWarningValues)
+      const viewModel = new ViewModel(options)
+      expect(viewModel).to.include({
+        metaDescription: 'Flooding information and advice for the area: A description.',
+        metaCanonical: '/target-area/ABCDW001',
+        pageTitle: 'Flood warning for TA #1'
+      })
+    })
+    it('should remove spaces and terminate description with a single full stop', async () => {
+      const ViewModel = proxyquire('../../server/models/views/target-area', {})
+      const targetAreaValues = {
+        code: 'ABCDW001',
+        description: 'A description.  '
+      }
+      const floodWarningValues = {}
+      const options = getTargetAreaAndWarning(targetAreaValues, floodWarningValues)
+      const viewModel = new ViewModel(options)
+      expect(viewModel).to.include({
+        areaDescription: 'Flood warning area: A description.'
+      })
+    })
+    it('should add a full stop to the end of the description when one is not present', async () => {
+      const ViewModel = proxyquire('../../server/models/views/target-area', {})
+      const targetAreaValues = {
+        code: 'ABCDW001',
+        description: 'A description'
+      }
+      const floodWarningValues = {}
+      const options = getTargetAreaAndWarning(targetAreaValues, floodWarningValues)
+      const viewModel = new ViewModel(options)
+      expect(viewModel).to.include({
+        areaDescription: 'Flood warning area: A description.'
+      })
+    })
+  })
   describe('parentTargetArea assignment', () => {
     const ViewModel = proxyquire('../../server/models/views/target-area', {})
     it('parentAreaAlert should be false when no parent TA exists', async () => {
@@ -229,34 +275,6 @@ describe('target area model test', () => {
       })
       expect(viewModel).to.include({
         pageTitle: 'Flood warning for Riverside View, Newtown'
-      })
-    })
-  })
-  describe('Description handling', () => {
-    it('should remove spaces and terminate description with a single full stop', async () => {
-      const ViewModel = proxyquire('../../server/models/views/target-area', {})
-      const targetAreaValues = {
-        code: 'ABCDW001',
-        description: 'A description.  '
-      }
-      const floodWarningValues = {}
-      const options = getTargetAreaAndWarning(targetAreaValues, floodWarningValues)
-      const viewModel = new ViewModel(options)
-      expect(viewModel).to.include({
-        areaDescription: 'Flood warning area: A description.'
-      })
-    })
-    it('should add a full stop to the end of the description when one is not present', async () => {
-      const ViewModel = proxyquire('../../server/models/views/target-area', {})
-      const targetAreaValues = {
-        code: 'ABCDW001',
-        description: 'A description'
-      }
-      const floodWarningValues = {}
-      const options = getTargetAreaAndWarning(targetAreaValues, floodWarningValues)
-      const viewModel = new ViewModel(options)
-      expect(viewModel).to.include({
-        areaDescription: 'Flood warning area: A description.'
       })
     })
   })

--- a/test/models/target-area.js
+++ b/test/models/target-area.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const Lab = require('@hapi/lab')
+const { expect } = require('@hapi/code')
+const { describe, it } = exports.lab = Lab.script()
+const fakeTargetAreaFloodData = require('../data/fakeTargetAreaFloodData.json')
+const proxyquire = require('proxyquire')
+
+const ViewModel = proxyquire('../../server/models/views/target-area', {
+  '../../../server/config': {
+    floodRiskUrl: 'http://cyltfr.org.uk',
+    bingKeyMaps: 'bing-key'
+  }
+})
+
+describe('target area model test', () => {
+  describe('CYLTFR options', () => {
+    const options = {
+      area: fakeTargetAreaFloodData.area,
+      flood: fakeTargetAreaFloodData.floods[0]
+    }
+    const viewModel = new ViewModel(options)
+    it('should return return a populated model class', async () => {
+      expect(viewModel).to.not.be.undefined()
+      expect(viewModel).to.be.an.instanceof(ViewModel)
+      expect(viewModel).to.include({
+        // TODO: add further included values
+        placeName: 'Upper River Derwent, Stonethwaite Beck and Derwent Water'
+      })
+    })
+    it('should return CYLTFR link values', async () => {
+      expect(viewModel).to.include({
+        displayLongTermLink: true,
+        floodRiskUrl: 'http://cyltfr.org.uk'
+      })
+    })
+  })
+  describe('Severity level', () => {
+    it('should populate the severity level details from the warning', async () => {
+      const options = {
+        area: fakeTargetAreaFloodData.area,
+        flood: fakeTargetAreaFloodData.floods[0]
+      }
+      const viewModel = new ViewModel(options)
+      expect(viewModel.severity).to.include({
+        title: 'Flood alert'
+      })
+      expect(viewModel).to.include({
+        pageTitle: 'Flood alert for Upper River Derwent, Stonethwaite Beck and Derwent Water'
+      })
+    })
+  })
+})

--- a/test/routes/target-area-2.js
+++ b/test/routes/target-area-2.js
@@ -1,0 +1,139 @@
+'use strict'
+
+const Hapi = require('@hapi/hapi')
+const Lab = require('@hapi/lab')
+const { expect } = require('@hapi/code')
+const sinon = require('sinon')
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { parse } = require('node-html-parser')
+const proxyquire = require('proxyquire')
+
+const fakeTargetAreaFloodData = require('../data/fakeTargetAreaFloodData.json')
+const { linkChecker, headingChecker } = require('../lib/helpers/html-expectations')
+
+describe('target-area route', () => {
+  let server
+
+  async function setupFakeModel (values) {
+    class FakeViewModel {
+      constructor (options) {
+        Object.assign(this, {
+          ...values,
+          ...options
+        })
+      }
+    }
+
+    const targetAreaRoute = proxyquire('../../server/routes/target-area', {
+      '../../server/models/views/target-area': FakeViewModel
+    })
+    const targetAreaPlugin = {
+      plugin: {
+        name: 'target',
+        register: (server, options) => {
+          server.route(targetAreaRoute)
+        }
+      }
+    }
+    await server.register(targetAreaPlugin)
+  }
+
+  async function getResponse (areaCode) {
+    const options = {
+      method: 'GET',
+      url: `/target-area/${areaCode}`
+    }
+
+    return await server.inject(options)
+  }
+
+  beforeEach(async () => {
+    server = Hapi.server({
+      port: 3000,
+      host: 'localhost',
+      routes: {
+        validate: {
+          options: {
+            abortEarly: false,
+            stripUnknown: true
+          }
+        }
+      }
+    })
+    await server.register(require('../../server/plugins/views'))
+    await server.register(require('../../server/plugins/session'))
+    await server.initialize()
+    server.method('flood.getFloodArea', sinon.stub().resolves(fakeTargetAreaFloodData.area))
+    server.method('flood.getFloods', sinon.stub().resolves(fakeTargetAreaFloodData))
+  })
+
+  it('should display heading', async () => {
+    const AREA_CODE = '011WAFDW'
+    setupFakeModel({
+      pageTitle: 'Flood alert for Upper River Derwent, Stonethwaite Beck and Derwent Water'
+    })
+
+    const response = await getResponse(AREA_CODE)
+
+    const root = parse(response.payload)
+    headingChecker(root, 'h1', 'Flood alert for Upper River Derwent, Stonethwaite Beck and Derwent Water')
+  })
+  it('should display related content links without sign up for flood warnings', async () => {
+    const AREA_CODE = '011WAFDW'
+    setupFakeModel({
+      pageTitle: 'Flood alert for Upper River Derwent, Stonethwaite Beck and Derwent Water',
+      floodRiskUrl: 'https://fake-flood-risk-url.com',
+      displayLongTermLink: true
+    })
+
+    const response = await getResponse(AREA_CODE)
+
+    expect(response.statusCode).to.equal(200)
+    const root = parse(response.payload)
+    const relatedContentLinks = root.querySelectorAll('.defra-related-items a')
+    expect(relatedContentLinks.length, 'Should be 5 related content links').to.equal(5)
+    linkChecker(relatedContentLinks, 'Prepare for flooding', 'https://www.gov.uk/prepare-for-flooding')
+    linkChecker(relatedContentLinks, 'What to do before or during a flood', 'https://www.gov.uk/guidance/flood-alerts-and-warnings-what-they-are-and-what-to-do')
+    linkChecker(relatedContentLinks, 'What to do after a flood', 'https://www.gov.uk/after-flood')
+    linkChecker(relatedContentLinks, 'Check your long term flood risk', 'https://fake-flood-risk-url.com')
+    linkChecker(relatedContentLinks, 'Report a flood', 'https://www.gov.uk/report-flood-cause')
+  })
+  it('should display river levels link', async () => {
+    const AREA_CODE = '011WAFDW'
+    setupFakeModel({
+      pageTitle: 'Flood alert for Upper River Derwent, Stonethwaite Beck and Derwent Water',
+      targetArea: AREA_CODE
+    })
+
+    const response = await getResponse(undefined)
+
+    expect(response.statusCode).to.equal(200)
+    const root = parse(response.payload)
+    linkChecker(root.querySelectorAll('a'),
+      'Find a river, sea, groundwater or rainfall level in this area',
+      `/river-and-sea-levels/target-area/${AREA_CODE}`
+    )
+  })
+  it('should return 404 if no code provided', async () => {
+    setupFakeModel({})
+
+    const options = {
+      method: 'GET',
+      url: '/target-area/'
+    }
+
+    const response = await server.inject(options)
+    expect(response.statusCode).to.equal(404)
+  })
+  it('should return 404 if no code provided', async () => {
+    setupFakeModel({})
+
+    const options = {
+      method: 'GET',
+      url: '/target-area/'
+    }
+
+    const response = await server.inject(options)
+    expect(response.statusCode).to.equal(404)
+  })
+})

--- a/test/routes/target-area-2.js
+++ b/test/routes/target-area-2.js
@@ -8,7 +8,7 @@ const { describe, it, beforeEach } = exports.lab = Lab.script()
 const { parse } = require('node-html-parser')
 const proxyquire = require('proxyquire')
 
-const fakeTargetAreaFloodData = require('../data/fakeTargetAreaFloodData.json')
+const { getWarning, getTargetArea } = require('../lib/helpers/data-builders')
 const { linkChecker, headingChecker } = require('../lib/helpers/html-expectations')
 
 describe('target-area route', () => {
@@ -63,8 +63,12 @@ describe('target-area route', () => {
     await server.register(require('../../server/plugins/views'))
     await server.register(require('../../server/plugins/session'))
     await server.initialize()
-    server.method('flood.getFloodArea', sinon.stub().resolves(fakeTargetAreaFloodData.area))
-    server.method('flood.getFloods', sinon.stub().resolves(fakeTargetAreaFloodData))
+
+    const area = getTargetArea({ code: 'ABCDW001' })
+    const warning = getWarning({ ta_code: 'ABCDW001' })
+
+    server.method('flood.getFloodArea', sinon.stub().resolves(area))
+    server.method('flood.getFloods', sinon.stub().resolves({ floods: [warning] }))
   })
 
   it('should display heading', async () => {
@@ -113,17 +117,6 @@ describe('target-area route', () => {
       'Find a river, sea, groundwater or rainfall level in this area',
       `/river-and-sea-levels/target-area/${AREA_CODE}`
     )
-  })
-  it('should return 404 if no code provided', async () => {
-    setupFakeModel({})
-
-    const options = {
-      method: 'GET',
-      url: '/target-area/'
-    }
-
-    const response = await server.inject(options)
-    expect(response.statusCode).to.equal(404)
   })
   it('should return 404 if no code provided', async () => {
     setupFakeModel({})


### PR DESCRIPTION
- **https://eaflood.atlassian.net/browse/FSR-596**
- **https://eaflood.atlassian.net/browse/FSR-1191**
- **Add initial tests for target area model**
- **Added tests for target-area route which use proxyquire**
- **Extend target area model tests and fix bug**
- **Extend tests and switch to constructing areas and warnings**
- **Fix bugs in "Removed" messaging (FSR-1191) and meta description and extend tests**
- **Remove default id - should explicitly set it**
- **Remove last usage of json file**
- **Move data builders into their own module for greater utility**
