### PR TITLE
FSR-1192 | Add defensive and cleanup measures to release creation GitHub action 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,6 @@ jobs:
           git switch -c $RELEASE_BRANCH
           git add .
           git commit -m "Bump version number (${VERSION})"
-          git push origin $RELEASE_BRANCH
         env:
           FLOOD_APP_BING_KEY: "${{ secrets.FLOOD_APP_BING_KEY }}"
           FLOOD_APP_BING_KEY_LOCATION: "${{ secrets.FLOOD_APP_BING_KEY_LOCATION }}"
@@ -104,9 +103,11 @@ jobs:
               --template "release-docs/template.njk"
             git add $release_notes_file
             git commit --no-verify -m "Add release notes (${VERSION})"
-            git push origin $RELEASE_BRANCH
             echo RELEASE_NOTES_FILE=$release_notes_file >> "$GITHUB_ENV"
           fi
+
+      - name: Push changes
+        run: git push origin $RELEASE_BRANCH
 
       - name: Create Draft PRs
         run: |
@@ -121,3 +122,11 @@ jobs:
         env:
           # use PAT token with repo scope (github.token didn't work)
           GH_TOKEN: ${{ secrets.GH_WORKFLOW }}
+
+      - name: Clean up
+        if: ${{ failure() }}
+        run: |
+          if git ls-remote --exit-code origin "refs/heads/${RELEASE_BRANCH}"; then
+            echo "Action failed, removing created release branch"
+            git push --delete origin $RELEASE_BRANCH
+          fi

--- a/release-docs/template.njk
+++ b/release-docs/template.njk
@@ -6,11 +6,12 @@
 
 ## Sense Check
 
+* Note that this is the definitive release notes for WebOps. The release notes in flood-service and flood-db are for CFF dev team use only.
 * Cross check the list of Jira tickets below with those in the Jira release linked to above and update where needed
-* Add additional Jira tickets from the related release notes:
-  * [flood-service](https://github.com/DEFRA/flood-service/blob/release/{{ version }}/release-docs/CFF-{{ version }}.md)
+* Add additional Jira tickets from the related release notes in the 'Release {{ version }}' PR's created in:
+  * [flood-service](https://github.com/DEFRA/flood-service)
 {% if dbChanges %}
-  * [flood-db](https://github.com/DEFRA/flood-db/blob/release{{ version }}/release-docs/CFF-{{ version }}.md)
+  * [flood-db](https://github.com/DEFRA/flood-db)
 {% endif %}
 * Add any required infrastructure changes such as redirects to the infrastructure changes section below
 * Once this sense check is done, delete this section

--- a/test/scripts.js
+++ b/test/scripts.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const Lab = require('@hapi/lab')
+const { expect } = require('@hapi/code')
+const { describe, it } = exports.lab = Lab.script()
+
+async function executeNpmScript (scriptName) {
+  const util = require('util')
+  const exec = util.promisify(require('child_process').exec)
+  try {
+    const { stdout, stderr } = await exec(`npm run ${scriptName}`)
+    return { stdout, stderr }
+  } catch (error) {
+    return { stdout: '', stderr: error.stderr }
+  }
+}
+describe('scripts', () => {
+  it('should run npm create-release-notes successfully', async () => {
+    // this test is to check that all the necessary modules are installed following the accidental
+    // removal of nunjucks and yargs which wasn't picked up until the create release github action
+    // was run
+    const { stdout, stderr } = await executeNpmScript('create-release-notes -- --help')
+
+    expect(stderr).to.be.empty()
+    expect(stdout).to.contain('node release-docs/lib/create-release-notes.js --help')
+  })
+})

--- a/test/scripts.js
+++ b/test/scripts.js
@@ -15,7 +15,7 @@ async function executeNpmScript (scriptName) {
   }
 }
 describe('scripts', () => {
-  it('should run npm create-release-notes successfully', async () => {
+  it('should run help for create-release-notes successfully', async () => {
     // this test is to check that all the necessary modules are installed following the accidental
     // removal of nunjucks and yargs which wasn't picked up until the create release github action
     // was run


### PR DESCRIPTION
* don't push changes until after both version bump and release note creation
* delete release branch if it exists and any step fails

Note: need to add these defensive measures to the workflow in flood-service too