### PR TITLE
FSR-0000 | allow git to decide merge strategy

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-        
+
       - name: Setup version env vars
         run: |
           version=${{ github.event.inputs.version }}
@@ -44,6 +44,26 @@ jobs:
           echo RELEASE_BRANCH="release/$version" >> "$GITHUB_ENV"
           echo TAG_VERSION="v$version" >> "$GITHUB_ENV"
           echo RELEASE_NOTES_FILE="./release-docs/CFF-${version}.md" >> "$GITHUB_ENV"
+
+      - name: Check PR's approved
+        run: |
+            function prCheck () {
+              REPO=$1
+              BASE=$2
+              gh pr list --repo $REPO --json title,mergeStateStatus,state,reviews --state OPEN --base $BASE --head $RELEASE_BRANCH --jq '.[] | [ select(.mergeStateStatus == "CLEAN" and .reviews[].state == "APPROVED") ]'
+              COUNT=$(gh pr list --repo $REPO --json title,mergeStateStatus,state,reviews --state OPEN --base $BASE --head $RELEASE_BRANCH --jq '.[] | [ select(.mergeStateStatus == "CLEAN" and .reviews[].state == "APPROVED") ] | length ')
+              if [ "$COUNT" -ne 1 ]; then
+                echo "Error: PR for merging $REPO $RELEASE_BRANCH into $BASE needs to be ready to merge and approved." >&2
+                exit 1
+              fi
+            }
+            prCheck $GITHUB_REPOSITORY_OWNER/flood-app master
+            prCheck $GITHUB_REPOSITORY_OWNER/flood-app development
+            prCheck $GITHUB_REPOSITORY_OWNER/flood-service master
+            prCheck $GITHUB_REPOSITORY_OWNER/flood-service development
+        env:
+          # create classic PAT and then run `gh secret set GH_WORKFLOW`
+          GH_TOKEN: ${{ secrets.GH_WORKFLOW }}
 
       - name: Check branch exists
         run: |

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -58,8 +58,8 @@ jobs:
           git config --global user.name "GitHub Actions"
           git switch $RELEASE_BRANCH
           git switch master
-          git merge --ff-only $RELEASE_BRANCH
-          git push
+          git merge --no-edit $RELEASE_BRANCH
+          git push origin master
 
       - name: Create GitHub Release
         run: gh release create $TAG_VERSION --title "Release $VERSION" --notes "[release notes](/$RELEASE_NOTES_FILE)"
@@ -70,8 +70,8 @@ jobs:
       - name: Merge release branch into development
         run: |
           git switch development
-          git merge --ff-only $RELEASE_BRANCH
-          git push
+          git merge --no-edit $RELEASE_BRANCH
+          git push origin development
 
       - name: Trigger Merge Release Branch for flood-service
         run: gh workflow run --repo  "$GITHUB_REPOSITORY_OWNER/flood-service" merge.yml -f version="$VERSION"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -34,9 +34,6 @@ jobs:
         with:
           node-version: '18'
 
-      - name: Install dependencies
-        run: npm install
-
       - name: Setup version env vars
         run: |
           version=${{ github.event.inputs.version }}
@@ -45,32 +42,34 @@ jobs:
           echo TAG_VERSION="v$version" >> "$GITHUB_ENV"
           echo RELEASE_NOTES_FILE="./release-docs/CFF-${version}.md" >> "$GITHUB_ENV"
 
-      - name: Check PR's approved
-        run: |
-            function prCheck () {
-              REPO=$1
-              BASE=$2
-              gh pr list --repo $REPO --json title,mergeStateStatus,state,reviews --state OPEN --base $BASE --head $RELEASE_BRANCH --jq '.[] | [ select(.mergeStateStatus == "CLEAN" and .reviews[].state == "APPROVED") ]'
-              COUNT=$(gh pr list --repo $REPO --json title,mergeStateStatus,state,reviews --state OPEN --base $BASE --head $RELEASE_BRANCH --jq '.[] | [ select(.mergeStateStatus == "CLEAN" and .reviews[].state == "APPROVED") ] | length ')
-              if [ "$COUNT" -ne 1 ]; then
-                echo "Error: PR for merging $REPO $RELEASE_BRANCH into $BASE needs to be ready to merge and approved." >&2
-                exit 1
-              fi
-            }
-            prCheck $GITHUB_REPOSITORY_OWNER/flood-app master
-            prCheck $GITHUB_REPOSITORY_OWNER/flood-app development
-            prCheck $GITHUB_REPOSITORY_OWNER/flood-service master
-            prCheck $GITHUB_REPOSITORY_OWNER/flood-service development
-        env:
-          # create classic PAT and then run `gh secret set GH_WORKFLOW`
-          GH_TOKEN: ${{ secrets.GH_WORKFLOW }}
-
       - name: Check branch exists
         run: |
           if ! git ls-remote --exit-code origin "refs/heads/${RELEASE_BRANCH}"; then
             echo "Error: Branch ${RELEASE_BRANCH} does not exist." >&2
             exit 1
           fi
+
+      - name: Check PR's approved
+        run: |
+            function prCheck () {
+              REPO=$1
+              BASE=$2
+              STATE=$(gh pr list --repo $GITHUB_REPOSITORY_OWNER/$REPO --json title,mergeStateStatus,state,reviews --state OPEN --base $BASE --head $RELEASE_BRANCH --jq '.[] | select(.mergeStateStatus == "CLEAN" and .reviews[].state == "APPROVED") | .reviews[].state ')
+              if [ "$STATE" != "APPROVED" ]; then
+                echo "Error: PR for merging $GITHUB_REPOSITORY_OWNER/$REPO $RELEASE_BRANCH into $BASE needs to be ready to merge and approved. (STATE=$STATE)" >&2
+                exit 1
+              fi
+            }
+            prCheck flood-app master
+            prCheck flood-app development
+            prCheck flood-service master
+            prCheck flood-service development
+        env:
+          # create classic PAT and then run `gh secret set GH_WORKFLOW`
+          GH_TOKEN: ${{ secrets.GH_WORKFLOW }}
+
+      - name: Install dependencies
+        run: npm install
 
       - name: Merge release branch into master
         run: |


### PR DESCRIPTION
Merge of release to dev was failing because a commit had been made to development and a ff merge was not possible.

This change will allow git to do a ff when it can.

Also, added checks on the PR's to ensure they are all approved before allowing merge.
