### PR TITLE
FSR-0000 | Example context-footer tests

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -34,9 +34,6 @@ jobs:
         with:
           node-version: '18'
 
-      - name: Install dependencies
-        run: npm install
-        
       - name: Setup version env vars
         run: |
           version=${{ github.event.inputs.version }}
@@ -52,14 +49,36 @@ jobs:
             exit 1
           fi
 
+      - name: Check PR's approved
+        run: |
+            function prCheck () {
+              REPO=$1
+              BASE=$2
+              STATE=$(gh pr list --repo $GITHUB_REPOSITORY_OWNER/$REPO --json title,mergeStateStatus,state,reviews --state OPEN --base $BASE --head $RELEASE_BRANCH --jq '.[] | select(.mergeStateStatus == "CLEAN" and .reviews[].state == "APPROVED") | .reviews[].state ')
+              if [ "$STATE" != "APPROVED" ]; then
+                echo "Error: PR for merging $GITHUB_REPOSITORY_OWNER/$REPO $RELEASE_BRANCH into $BASE needs to be ready to merge and approved. (STATE=$STATE)" >&2
+                exit 1
+              fi
+            }
+            prCheck flood-app master
+            prCheck flood-app development
+            prCheck flood-service master
+            prCheck flood-service development
+        env:
+          # create classic PAT and then run `gh secret set GH_WORKFLOW`
+          GH_TOKEN: ${{ secrets.GH_WORKFLOW }}
+
+      - name: Install dependencies
+        run: npm install
+
       - name: Merge release branch into master
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"
           git switch $RELEASE_BRANCH
           git switch master
-          git merge --ff-only $RELEASE_BRANCH
-          git push
+          git merge --no-edit $RELEASE_BRANCH
+          git push origin master
 
       - name: Create GitHub Release
         run: gh release create $TAG_VERSION --title "Release $VERSION" --notes "[release notes](/$RELEASE_NOTES_FILE)"
@@ -70,8 +89,8 @@ jobs:
       - name: Merge release branch into development
         run: |
           git switch development
-          git merge --ff-only $RELEASE_BRANCH
-          git push
+          git merge --no-edit $RELEASE_BRANCH
+          git push origin development
 
       - name: Trigger Merge Release Branch for flood-service
         run: gh workflow run --repo  "$GITHUB_REPOSITORY_OWNER/flood-service" merge.yml -f version="$VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,6 @@ jobs:
           git switch -c $RELEASE_BRANCH
           git add .
           git commit -m "Bump version number (${VERSION})"
-          git push origin $RELEASE_BRANCH
         env:
           FLOOD_APP_BING_KEY: "${{ secrets.FLOOD_APP_BING_KEY }}"
           FLOOD_APP_BING_KEY_LOCATION: "${{ secrets.FLOOD_APP_BING_KEY_LOCATION }}"
@@ -104,9 +103,11 @@ jobs:
               --template "release-docs/template.njk"
             git add $release_notes_file
             git commit --no-verify -m "Add release notes (${VERSION})"
-            git push origin $RELEASE_BRANCH
             echo RELEASE_NOTES_FILE=$release_notes_file >> "$GITHUB_ENV"
           fi
+
+      - name: Push changes
+        run: git push origin $RELEASE_BRANCH
 
       - name: Create Draft PRs
         run: |
@@ -121,3 +122,11 @@ jobs:
         env:
           # use PAT token with repo scope (github.token didn't work)
           GH_TOKEN: ${{ secrets.GH_WORKFLOW }}
+
+      - name: Clean up
+        if: ${{ failure() }}
+        run: |
+          if git ls-remote --exit-code origin "refs/heads/${RELEASE_BRANCH}"; then
+            echo "Action failed, removing created release branch"
+            git push --delete origin $RELEASE_BRANCH
+          fi

--- a/release-docs/template.njk
+++ b/release-docs/template.njk
@@ -6,11 +6,12 @@
 
 ## Sense Check
 
+* Note that this is the definitive release notes for WebOps. The release notes in flood-service and flood-db are for CFF dev team use only.
 * Cross check the list of Jira tickets below with those in the Jira release linked to above and update where needed
-* Add additional Jira tickets from the related release notes:
-  * [flood-service](https://github.com/DEFRA/flood-service/blob/release/{{ version }}/release-docs/CFF-{{ version }}.md)
+* Add additional Jira tickets from the related release notes in the 'Release {{ version }}' PR's created in:
+  * [flood-service](https://github.com/DEFRA/flood-service)
 {% if dbChanges %}
-  * [flood-db](https://github.com/DEFRA/flood-db/blob/release{{ version }}/release-docs/CFF-{{ version }}.md)
+  * [flood-db](https://github.com/DEFRA/flood-db)
 {% endif %}
 * Add any required infrastructure changes such as redirects to the infrastructure changes section below
 * Once this sense check is done, delete this section

--- a/test/routes/web-chat.js
+++ b/test/routes/web-chat.js
@@ -81,7 +81,7 @@ describe('context-footer', () => {
       server.method('flood.getFloodArea', sinon.stub().resolves(area))
       server.method('flood.getFloods', sinon.stub().resolves({ floods: [] }))
     })
-    it('should display webchat link', async () => {
+    it('should be possible to enable webchat link', async () => {
       await server.register(
         proxyquire('../../server/plugins/views', {
           '../../server/config': { webchat: { enabled: true } }
@@ -93,7 +93,7 @@ describe('context-footer', () => {
       const root = parse(response.payload)
       webchatParagraphChecker(root, true)
     })
-    it('should not display webchat link', async () => {
+    it('should be possible to disable webchat link', async () => {
       await server.register(
         proxyquire('../../server/plugins/views', {
           '../../server/config': { webchat: { enabled: false } }
@@ -117,6 +117,8 @@ describe('context-footer', () => {
       const locationRoute = proxyquire('../../server/routes/location', {
         '../../server/models/views/location': FakeViewModel,
         '../../server/services/location': {
+          // the location data below would be better created using a
+          // data builder (see test/lib/helpers/data-builders.js)
           find: sinon.stub().resolves([
             {
               name: 'Knaresborough, North Yorkshire',
@@ -157,7 +159,7 @@ describe('context-footer', () => {
       server.method('flood.getStationsWithin', sinon.stub().resolves([]))
       server.method('flood.getOutlook', sinon.stub().resolves({}))
     })
-    it('should display webchat link', async () => {
+    it('should be possible to enable webchat link', async () => {
       await server.register(
         proxyquire('../../server/plugins/views', {
           '../../server/config': { webchat: { enabled: true } }
@@ -169,7 +171,7 @@ describe('context-footer', () => {
       const root = parse(response.payload)
       webchatParagraphChecker(root, true)
     })
-    it('should not display webchat link', async () => {
+    it('should be possible to disable webchat link', async () => {
       await server.register(
         proxyquire('../../server/plugins/views', {
           '../../server/config': { webchat: { enabled: false } }

--- a/test/routes/web-chat.js
+++ b/test/routes/web-chat.js
@@ -42,84 +42,62 @@ describe('context-footer', () => {
   beforeEach(async () => {
   })
 
-  it('target area page should display webchat link', async () => {
-    const FakeViewModel = sinon.spy(function (options) {
-      Object.assign(this, {
-        pageTitle: 'Page Title',
-        ...options
+  describe('target area page', () => {
+    beforeEach(async () => {
+      const FakeViewModel = sinon.spy(function (options) {
+        Object.assign(this, {
+          pageTitle: 'Page Title',
+          ...options
+        })
       })
-    })
 
-    const targetAreaRoute = proxyquire('../../server/routes/target-area', {
-      '../../server/models/views/target-area': FakeViewModel
-    })
-    const targetAreaPlugin = {
-      plugin: {
-        name: 'target',
-        register: (server, options) => {
-          server.route(targetAreaRoute)
+      const targetAreaRoute = proxyquire('../../server/routes/target-area', {
+        '../../server/models/views/target-area': FakeViewModel
+      })
+      const targetAreaPlugin = {
+        plugin: {
+          name: 'target',
+          register: (server, options) => {
+            server.route(targetAreaRoute)
+          }
         }
       }
-    }
-    await setupServer([
-      targetAreaPlugin,
-      proxyquire('../../server/plugins/views', {
-        '../../server/config': { webchat: { enabled: true } }
-      }),
-      proxyquire('../../server/plugins/session', {})
-    ])
+      await setupServer([
+        targetAreaPlugin,
+        proxyquire('../../server/plugins/session', {})
+      ])
+      const area = getTargetArea({ code: '011WAFDW' })
 
-    const area = getTargetArea({ code: '011WAFDW' })
-
-    server.method('flood.getFloodArea', sinon.stub().resolves(area))
-    server.method('flood.getFloods', sinon.stub().resolves({ floods: [] }))
-
-    const response = await getResponse('011WAFDW')
-
-    expect(response.statusCode).to.equal(200)
-    const root = parse(response.payload)
-    const text = 'Talk to a Floodline adviser over webchat'
-    const pFound = root.querySelectorAll('p.govuk-\\!-margin-bottom-0').some(p => p.text.trim().startsWith(text))
-    expect(pFound, `p tag with text ${text} not found.`).to.be.true()
-  })
-  it('target area page should not display webchat link', async () => {
-    const FakeViewModel = sinon.spy(function (options) {
-      Object.assign(this, {
-        pageTitle: 'Page Title',
-        ...options
-      })
+      server.method('flood.getFloodArea', sinon.stub().resolves(area))
+      server.method('flood.getFloods', sinon.stub().resolves({ floods: [] }))
     })
+    it('should display webchat link', async () => {
+      await server.register(
+        proxyquire('../../server/plugins/views', {
+          '../../server/config': { webchat: { enabled: true } }
+        })
+      )
+      const response = await getResponse('011WAFDW')
 
-    const targetAreaRoute = proxyquire('../../server/routes/target-area', {
-      '../../server/models/views/target-area': FakeViewModel
+      expect(response.statusCode).to.equal(200)
+      const root = parse(response.payload)
+      const text = 'Talk to a Floodline adviser over webchat'
+      const pFound = root.querySelectorAll('p.govuk-\\!-margin-bottom-0').some(p => p.text.trim().startsWith(text))
+      expect(pFound, `p tag with text ${text} not found.`).to.be.true()
     })
-    const targetAreaPlugin = {
-      plugin: {
-        name: 'target',
-        register: (server, options) => {
-          server.route(targetAreaRoute)
-        }
-      }
-    }
-    await setupServer([
-      targetAreaPlugin,
-      proxyquire('../../server/plugins/views', {
-        '../../server/config': { webchat: { enabled: false } }
-      }),
-      proxyquire('../../server/plugins/session', {})
-    ])
+    it('should not display webchat link', async () => {
+      await server.register(
+        proxyquire('../../server/plugins/views', {
+          '../../server/config': { webchat: { enabled: false } }
+        })
+      )
+      const response = await getResponse('011WAFDW')
 
-    const area = getTargetArea({ code: '011WAFDW' })
-
-    server.method('flood.getFloodArea', sinon.stub().resolves(area))
-    server.method('flood.getFloods', sinon.stub().resolves({ floods: [] }))
-
-    const response = await getResponse('011WAFDW')
-
-    expect(response.statusCode).to.equal(200)
-    const root = parse(response.payload)
-    const text = 'Talk to a Floodline adviser over webchat'
-    const pFound = root.querySelectorAll('p.govuk-\\!-margin-bottom-0').some(p => p.text.trim().startsWith(text))
-    expect(pFound, `p tag with text ${text} found.`).to.be.false()
+      expect(response.statusCode).to.equal(200)
+      const root = parse(response.payload)
+      const text = 'Talk to a Floodline adviser over webchat'
+      const pFound = root.querySelectorAll('p.govuk-\\!-margin-bottom-0').some(p => p.text.trim().startsWith(text))
+      expect(pFound, `p tag with text ${text} found.`).to.be.false()
+    })
   })
 })

--- a/test/routes/web-chat.js
+++ b/test/routes/web-chat.js
@@ -1,0 +1,125 @@
+'use strict'
+
+const Hapi = require('@hapi/hapi')
+const Lab = require('@hapi/lab')
+const { expect } = require('@hapi/code')
+const sinon = require('sinon')
+const { describe, it, beforeEach } = exports.lab = Lab.script()
+const { parse } = require('node-html-parser')
+const proxyquire = require('proxyquire')
+
+const { getTargetArea } = require('../lib/helpers/data-builders')
+
+describe('context-footer', () => {
+  let server
+
+  async function getResponse (areaCode) {
+    const options = {
+      method: 'GET',
+      url: `/target-area/${areaCode}`
+    }
+
+    return await server.inject(options)
+  }
+
+  async function setupServer (plugins) {
+    server = Hapi.server({
+      port: 3000,
+      host: 'localhost',
+      routes: {
+        validate: {
+          options: {
+            abortEarly: false,
+            stripUnknown: true
+          }
+        }
+      }
+    })
+    await server.register(plugins)
+    await server.initialize()
+  }
+
+  beforeEach(async () => {
+  })
+
+  it('target area page should display webchat link', async () => {
+    const FakeViewModel = sinon.spy(function (options) {
+      Object.assign(this, {
+        pageTitle: 'Page Title',
+        ...options
+      })
+    })
+
+    const targetAreaRoute = proxyquire('../../server/routes/target-area', {
+      '../../server/models/views/target-area': FakeViewModel
+    })
+    const targetAreaPlugin = {
+      plugin: {
+        name: 'target',
+        register: (server, options) => {
+          server.route(targetAreaRoute)
+        }
+      }
+    }
+    await setupServer([
+      targetAreaPlugin,
+      proxyquire('../../server/plugins/views', {
+        '../../server/config': { webchat: { enabled: true } }
+      }),
+      proxyquire('../../server/plugins/session', {})
+    ])
+
+    const area = getTargetArea({ code: '011WAFDW' })
+
+    server.method('flood.getFloodArea', sinon.stub().resolves(area))
+    server.method('flood.getFloods', sinon.stub().resolves({ floods: [] }))
+
+    const response = await getResponse('011WAFDW')
+
+    expect(response.statusCode).to.equal(200)
+    const root = parse(response.payload)
+    const text = 'Talk to a Floodline adviser over webchat'
+    const pFound = root.querySelectorAll('p.govuk-\\!-margin-bottom-0').some(p => p.text.trim().startsWith(text))
+    expect(pFound, `p tag with text ${text} not found.`).to.be.true()
+  })
+  it('target area page should not display webchat link', async () => {
+    const FakeViewModel = sinon.spy(function (options) {
+      Object.assign(this, {
+        pageTitle: 'Page Title',
+        ...options
+      })
+    })
+
+    const targetAreaRoute = proxyquire('../../server/routes/target-area', {
+      '../../server/models/views/target-area': FakeViewModel
+    })
+    const targetAreaPlugin = {
+      plugin: {
+        name: 'target',
+        register: (server, options) => {
+          server.route(targetAreaRoute)
+        }
+      }
+    }
+    await setupServer([
+      targetAreaPlugin,
+      proxyquire('../../server/plugins/views', {
+        '../../server/config': { webchat: { enabled: false } }
+      }),
+      proxyquire('../../server/plugins/session', {})
+    ])
+
+    const area = getTargetArea({ code: '011WAFDW' })
+
+    server.method('flood.getFloodArea', sinon.stub().resolves(area))
+    server.method('flood.getFloods', sinon.stub().resolves({ floods: [] }))
+
+    const response = await getResponse('011WAFDW')
+
+    expect(response.statusCode).to.equal(200)
+    const root = parse(response.payload)
+    const text = 'Talk to a Floodline adviser over webchat'
+    const pFound = root.querySelectorAll('p.govuk-\\!-margin-bottom-0').some(p => p.text.trim().startsWith(text))
+    expect(pFound, `p tag with text ${text} found.`).to.be.false()
+  })
+})

--- a/test/scripts.js
+++ b/test/scripts.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const Lab = require('@hapi/lab')
+const { expect } = require('@hapi/code')
+const { describe, it } = exports.lab = Lab.script()
+
+async function executeNpmScript (scriptName) {
+  const util = require('util')
+  const exec = util.promisify(require('child_process').exec)
+  try {
+    const { stdout, stderr } = await exec(`npm run ${scriptName}`)
+    return { stdout, stderr }
+  } catch (error) {
+    return { stdout: '', stderr: error.stderr }
+  }
+}
+describe('scripts', () => {
+  it('should run help for create-release-notes successfully', async () => {
+    // this test is to check that all the necessary modules are installed following the accidental
+    // removal of nunjucks and yargs which wasn't picked up until the create release github action
+    // was run
+    const { stdout, stderr } = await executeNpmScript('create-release-notes -- --help')
+
+    expect(stderr).to.be.empty()
+    expect(stdout).to.contain('node release-docs/lib/create-release-notes.js --help')
+  })
+})


### PR DESCRIPTION
This is an example of how I think our route tests should be structured. 

They should be focused on testing the logic in the route only and stub out route dependencies. They use a fake view model so don't test the logic in there. There needs to be seperate tests for the view model. Doing this removes the need to stub dependencies of dependencies which is what makes the current route tests so complicated and brittle.

There is another example of this approach which includes view model tests in #678