### PR TITLE
FSR-1062 | Update Visibility and Icons for Tidal Stations and Correct Naming

### DIFF
--- a/server/src/js/components/map/live.js
+++ b/server/src/js/components/map/live.js
@@ -156,11 +156,15 @@ function LiveMap (mapId, options) {
           state = props.type === 'G' ? 'ground' : 'river'
         }
       } else if (props.type === 'C') {
-        // Tide
-        if (props.status === 'Suspended' || props.status === 'Closed' || (!props.value && !props.iswales)) {
-          state = 'seaError'
+        // Tide or River based on river_name
+        if (props.river_name !== 'Sea Levels') {
+          state = 'river'
         } else {
-          state = 'sea'
+          if (props.status === 'Suspended' || props.status === 'Closed' || (!props.value && !props.iswales)) {
+            state = 'seaError'
+          } else {
+            state = 'sea'
+          }
         }
       } else if (props.type === 'R') {
         // Rainfall
@@ -183,8 +187,10 @@ function LiveMap (mapId, options) {
         (props.severity_value && props.severity_value === 4 && lyrCodes.includes('tr')) ||
         // Rivers
         (ref === 'stations' && ['S', 'M'].includes(props.type) && lyrCodes.includes('ri')) ||
+        // Tidal Rivers
+        (ref === 'stations' && props.type === 'C' && props.river_name !== 'Sea Levels' && lyrCodes.includes('ri')) ||
         // Sea
-        (ref === 'stations' && props.type === 'C' && lyrCodes.includes('ti')) ||
+        (ref === 'stations' && props.type === 'C' && props.river_name === 'Sea Levels' && lyrCodes.includes('ti')) ||
         // Ground
         (ref === 'stations' && props.type === 'G' && lyrCodes.includes('gr')) ||
         // Rainfall

--- a/server/src/templates/info-live.html
+++ b/server/src/templates/info-live.html
@@ -31,7 +31,7 @@
 <div id="infoDescription">
     <strong class="defra-map-info__name">
         <a data-journey-click="Map:Map interaction:Map - Open station from tooltip" href="/station/{{ model.id }}">
-            {% if model.type === 'C' %}Sea Level{% elif model.type === 'G' %}Groundwater{% else %}{{ model.river }}{% endif %} at
+            {% if model.type === 'C' and model.river_name !== 'Sea Levels' %}{{model.river_name}}{%elif model.type === 'C'%}Sea Level{% elif model.type === 'G' %}Groundwater{% else %}{{ model.river }}{% endif %} at
             {{ model.name }}
             {% if model.iswales %} (Natural Resources Wales){% endif %}
         </a>


### PR DESCRIPTION
- Only sea stations now show on the map, excluding tidal stations.
- Tidal stations display the correct icon (river) and have the correct name without 'Sea Level' appended.
- Sea level stations are displayed when ‘Sea’ is selected in the Levels key, filtered by station_type = ‘C' and station.river_id = 'Sea Levels’.
- Tidal stations appear on the map when ‘River’ is selected in the Levels key.
- Updated setFeatureVisibility logic to filter and display stations based on the selected layers.
- Verified data consistency between GeoServer and the database.
