### PR TITLE
FSR-1660 | Updated Map Link Colour

### DIFF
--- a/server/src/sass/application.scss
+++ b/server/src/sass/application.scss
@@ -74,6 +74,7 @@ $govuk-breakpoints: (
 
 // Utilities
 @import "utilities/details";
+@import "utilities/station-links";
 @import "utilities/summary-list";
 
 // Datatables

--- a/server/src/sass/utilities/_station-links.scss
+++ b/server/src/sass/utilities/_station-links.scss
@@ -1,0 +1,8 @@
+.govuk-link--no-visited-state {
+  color: govuk-colour("blue");
+  text-decoration: underline;
+
+  &:visited {
+    color: govuk-colour("blue")!important;
+  }
+}

--- a/server/views/rainfall-station.html
+++ b/server/views/rainfall-station.html
@@ -54,7 +54,7 @@
             <div class="defra-navbar__group">
               <ul class="defra-navbar__list">
                 <li class="defra-navbar__item">
-                  <a href="/river-and-sea-levels/rainfall/{{model.stationId }}">Nearby levels</a>
+                  <a class="govuk-link govuk-link--no-visited-state" href="/river-and-sea-levels/rainfall/{{model.stationId }}">Nearby levels</a>
                 </li>
               </ul>
             </div>
@@ -142,7 +142,7 @@
   window.flood.model.zoom = 14
   window.flood.model.selectedId = `rainfall_stations.${window.flood.model.id}`
   window.flood.model.mapButtonText = 'Map',
-  window.flood.model.mapButtonClass = 'defra-link-icon-s',
+  window.flood.model.mapButtonClass = 'defra-link-icon-s govuk-link govuk-link--no-visited-state',
   window.flood.model.mapButtonType = 'link',
   window.flood.model.mapLayers = 'mv,rf',
   window.flood.model.data = {

--- a/server/views/station.html
+++ b/server/views/station.html
@@ -42,16 +42,16 @@
           <ul class="defra-navbar__list">
             {% if model.navigationLink.upstream %}
             <li class="defra-navbar__item">
-              <a href="/station/{{model.navigationLink.upstream}}">Upstream</a>
+              <a class="govuk-link govuk-link--no-visited-state" href="/station/{{model.navigationLink.upstream}}">Upstream</a>
             </li>
             {% endif %}
             {% if model.navigationLink.downstream %}
             <li class="defra-navbar__item">
-              <a href="/station/{{model.navigationLink.downstream}}">Downstream</a>
+              <a class="govuk-link govuk-link--no-visited-state" href="/station/{{model.navigationLink.downstream}}">Downstream</a>
             </li>
             {% endif %}
             <li class="defra-navbar__item">
-              <a href="/river-and-sea-levels/rloi/{{model.station.id}}">Nearby levels</a>
+              <a class="govuk-link govuk-link--no-visited-state" href="/river-and-sea-levels/rloi/{{model.station.id}}">Nearby levels</a>
             </li>
           </ul>
         </div>
@@ -339,15 +339,17 @@
   window.flood.model.telemetry = {{ model.telemetryRefined | dump | safe }}
   window.flood.model.bingMaps = {{ model.bingMaps | dump | safe }}
 
-  window.flood.model.mapButtonText = 'Map',
-    window.flood.model.mapButtonClass = 'defra-link-icon-s',
-    window.flood.model.mapButtonType = 'link',
-    window.flood.model.mapLayers = 'mv,ri,ti,gr,rf'
+  window.flood.model.mapButtonText = 'Map'
+  window.flood.model.mapButtonClass = 'defra-link-icon-s govuk-link govuk-link--no-visited-state'
+  window.flood.model.mapButtonType = 'link'
+  window.flood.model.mapLayers = 'mv,ri,ti,gr,rf'
+
   window.flood.model.data = {
     button: 'Station:Map View:Station - View map',
     checkBox: 'Station:Map interaction:Map - Layer interaction',
     aerial: 'Station:Map interaction:View-satelite-basemap'
   }
+  
   window.flood.model.centre = window.flood.model.centre.split(','),
     window.flood.model.selectedId = 'stations.' + window.flood.model.id +
     (window.location.pathname.includes('/downstream') ? '/downstream' : ''),

--- a/test/routes/river-and-sea-levels.js
+++ b/test/routes/river-and-sea-levels.js
@@ -328,10 +328,10 @@ describe('Route - River and Sea Levels', () => {
       const response = await server.inject(options)
 
       expect(response.statusCode).to.equal(200)
-      expect(response.payload).to.contain('<a href="/river-and-sea-levels/warrington?group=river" data-group-type="river">River (0)</a>')
-      expect(response.payload).to.contain('<a href="/river-and-sea-levels/warrington?group=sea" data-group-type="sea">Sea (0)</a>')
-      expect(response.payload).to.contain('<a href="/river-and-sea-levels/warrington?group=rainfall" data-group-type="rainfall">Rainfall (0)</a>')
-      expect(response.payload).to.contain('<a href="/river-and-sea-levels/warrington?group=groundwater" data-group-type="groundwater">Groundwater (1)</a>')
+      expect(response.payload).to.contain('href="/river-and-sea-levels/warrington?group=river" data-group-type="river">River (0)</a>')
+      expect(response.payload).to.contain('href="/river-and-sea-levels/warrington?group=sea" data-group-type="sea">Sea (0)</a>')
+      expect(response.payload).to.contain('href="/river-and-sea-levels/warrington?group=rainfall" data-group-type="rainfall">Rainfall (0)</a>')
+      expect(response.payload).to.contain('href="/river-and-sea-levels/warrington?group=groundwater" data-group-type="groundwater">Groundwater (1)</a>')
     })
 
     it('should return only rainfall stations', async () => {
@@ -411,9 +411,9 @@ describe('Route - River and Sea Levels', () => {
       const response = await server.inject(options)
 
       expect(response.statusCode).to.equal(200)
-      expect(response.payload).to.contain('<a href="/river-and-sea-levels/warrington?group=river" data-group-type="river">River (0)</a>')
-      expect(response.payload).to.contain('<a href="/river-and-sea-levels/warrington?group=sea" data-group-type="sea">Sea (0)</a>')
-      expect(response.payload).to.contain('<a href="/river-and-sea-levels/warrington?group=rainfall" data-group-type="rainfall">Rainfall (2)</a>')
+      expect(response.payload).to.contain('href="/river-and-sea-levels/warrington?group=river" data-group-type="river">River (0)</a>')
+      expect(response.payload).to.contain('href="/river-and-sea-levels/warrington?group=sea" data-group-type="sea">Sea (0)</a>')
+      expect(response.payload).to.contain('href="/river-and-sea-levels/warrington?group=rainfall" data-group-type="rainfall">Rainfall (2)</a>')
     })
 
     it('should handle funny latest value', async () => {
@@ -935,7 +935,7 @@ describe('Route - River and Sea Levels', () => {
       const response = await server.inject(options)
 
       expect(response.statusCode).to.equal(200)
-      expect(response.payload).to.contain('<a href="/river-and-sea-levels/Avon">')
+      expect(response.payload).to.contain('href="/river-and-sea-levels/Avon">')
     })
 
     it('should return multiple choice locations if place outside of england', async () => {

--- a/test/routes/station.js
+++ b/test/routes/station.js
@@ -384,8 +384,8 @@ describe('Route - Station', () => {
     expect(response.payload).to.contain('Normal')
     expect(response.payload).to.contain('Steady')
     expect(response.payload).to.contain('Normal range 0.15m to 3.50m')
-    expect(response.payload).to.contain('<a href="/river-and-sea-levels/rloi/5146">Nearby levels</a>')
-    expect(response.payload).to.contain('<a href="/station/5122">Upstream</a>')
+    expect(response.payload).to.contain('href="/river-and-sea-levels/rloi/5146">Nearby levels</a>')
+    expect(response.payload).to.contain('href="/station/5122">Upstream</a>')
     expect(response.payload).to.contain('href="/station-csv/5146"')
     expect(response.payload).to.contain('Download data CSV (12KB)')
   })
@@ -524,8 +524,8 @@ describe('Route - Station', () => {
     expect(response.payload).to.contain('High')
     expect(response.payload).to.contain('Falling')
     expect(response.payload).to.contain('Latest at 1:30am')
-    expect(response.payload).to.contain('<a href="/river-and-sea-levels/rloi/5146">Nearby levels</a>')
-    expect(response.payload).to.contain('<a href="/station/5122">Upstream</a>')
+    expect(response.payload).to.contain('href="/river-and-sea-levels/rloi/5146">Nearby levels</a>')
+    expect(response.payload).to.contain('href="/station/5122">Upstream</a>')
     expect(response.payload).to.not.contain('Go downstream</a>')
   })
 
@@ -663,8 +663,8 @@ describe('Route - Station', () => {
     expect(response.payload).to.contain('Low\n')
     expect(response.payload).to.contain('Rising')
     expect(response.payload).to.contain('Latest at 1:30am')
-    expect(response.payload).to.contain('<a href="/river-and-sea-levels/rloi/5146">Nearby levels</a>')
-    expect(response.payload).to.contain('<a href="/station/5122">Upstream</a>')
+    expect(response.payload).to.contain('href="/river-and-sea-levels/rloi/5146">Nearby levels</a>')
+    expect(response.payload).to.contain('href="/station/5122">Upstream</a>')
   })
 
   it('should return downstream', async () => {
@@ -797,9 +797,9 @@ describe('Route - Station', () => {
     const response = await server.inject(options)
     expect(response.statusCode).to.equal(200)
     expect(response.payload).to.contain('River Avon level downstream at Lilbourne - GOV.UK')
-    expect(response.payload).to.contain('<a href="/river-and-sea-levels/rloi/2042">Nearby levels</a>')
-    expect(response.payload).to.contain('<a href="/station/2042">Upstream</a>')
-    expect(response.payload).to.contain('<a href="/station/2043">Downstream</a>')
+    expect(response.payload).to.contain('href="/river-and-sea-levels/rloi/2042">Nearby levels</a>')
+    expect(response.payload).to.contain('href="/station/2042">Upstream</a>')
+    expect(response.payload).to.contain('href="/station/2043">Downstream</a>')
   })
 
   it('should return closed station', async () => {
@@ -1479,9 +1479,9 @@ describe('Route - Station', () => {
     expect(response.payload).to.contain('This station includes an automated model')
     expect(response.payload).to.contain('level in the model is')
     expect(response.payload).to.not.contain('<button class="defra-button-text govuk-!-margin-bottom-2" aria-controls="impact-list">Show historical events</button>')
-    expect(response.payload).to.contain('<a href="/station/7332">Upstream</a>')
-    expect(response.payload).to.contain('<a href="/station/7357">Downstream</a>')
-    expect(response.payload).to.contain('<a href="/river-and-sea-levels/rloi/7333">Nearby levels</a>')
+    expect(response.payload).to.contain('href="/station/7332">Upstream</a>')
+    expect(response.payload).to.contain('href="/station/7357">Downstream</a>')
+    expect(response.payload).to.contain('href="/river-and-sea-levels/rloi/7333">Nearby levels</a>')
   })
 
   it('should 200 with latest value over hour old but under 24 hours ', async () => {
@@ -1915,8 +1915,8 @@ describe('Route - Station', () => {
     expect(response.statusCode).to.equal(200)
     expect(response.payload).to.contain('River Ribble level at Walton-Le-Dale - GOV.UK')
     expect(response.payload).to.contain('This data feed was interrupted')
-    expect(response.payload).to.contain('<a href="/river-and-sea-levels/rloi/5146">Nearby levels</a>')
-    expect(response.payload).to.contain('<a href="/station/5122">Upstream</a>')
+    expect(response.payload).to.contain('href="/river-and-sea-levels/rloi/5146">Nearby levels</a>')
+    expect(response.payload).to.contain('href="/station/5122">Upstream</a>')
     expect(response.payload).to.contain('href="/station-csv/5146"')
     expect(response.payload).to.contain('Download data CSV (12KB)')
   })
@@ -2185,8 +2185,8 @@ describe('Route - Station', () => {
     expect(response.payload).to.contain('River Ribble level at Walton-Le-Dale - GOV.UK')
     expect(response.payload).to.contain('Steady')
     expect(response.payload).to.not.contain('Normal range ')
-    expect(response.payload).to.contain('<a href="/river-and-sea-levels/rloi/5146">Nearby levels</a>')
-    expect(response.payload).to.contain('<a href="/station/5122">Upstream</a>')
+    expect(response.payload).to.contain('href="/river-and-sea-levels/rloi/5146">Nearby levels</a>')
+    expect(response.payload).to.contain('href="/station/5122">Upstream</a>')
   })
 
   it('should set page title and h1 as coastal river name', async () => {
@@ -2556,8 +2556,8 @@ describe('Route - Station', () => {
     })
 
     expect(response.statusCode).to.equal(200)
-    expect(response.payload).to.include('<a href="/station/9382">Upstream</a>')
-    expect(response.payload).to.include('<a href="/station/9345">Downstream</a>')
+    expect(response.payload).to.include('href="/station/9382">Upstream</a>')
+    expect(response.payload).to.include('href="/station/9345">Downstream</a>')
   })
 
   it('GET /station/9382 redirects to the downstream view and shows correct navigation links for multi-reading station', async () => {
@@ -2647,8 +2647,8 @@ describe('Route - Station', () => {
     })
 
     expect(response.statusCode).to.equal(200)
-    expect(response.payload).to.include('<a href="/station/9045">Upstream</a>')
-    expect(response.payload).to.include('<a href="/station/9382/downstream">Downstream</a>')
+    expect(response.payload).to.include('href="/station/9045">Upstream</a>')
+    expect(response.payload).to.include('href="/station/9382/downstream">Downstream</a>')
   })
 
   it('GET /station/9045 navigates correctly to upstream and downstream views from a single station', async () => {
@@ -2738,8 +2738,8 @@ describe('Route - Station', () => {
     })
 
     expect(response.statusCode).to.equal(200)
-    expect(response.payload).to.include('<a href="/station/9382/downstream">Upstream</a>')
-    expect(response.payload).to.include('<a href="/station/8114">Downstream</a>')
+    expect(response.payload).to.include('href="/station/9382/downstream">Upstream</a>')
+    expect(response.payload).to.include('href="/station/8114">Downstream</a>')
   })
 
   it('GET /station/9382 shows correct upstream and downstream navigation links for multi to single upstream navigation', async () => {
@@ -2829,8 +2829,8 @@ describe('Route - Station', () => {
     })
 
     expect(response.statusCode).to.equal(200)
-    expect(response.payload).to.include('<a href="/station/9045">Upstream</a>')
-    expect(response.payload).to.include('<a href="/station/9382/downstream">Downstream</a>')
+    expect(response.payload).to.include('href="/station/9045">Upstream</a>')
+    expect(response.payload).to.include('href="/station/9382/downstream">Downstream</a>')
   })
 
   it('GET /station/9382/downstream shows correct upstream and downstream navigation links for multi to single downstream navigation', async () => {
@@ -2920,8 +2920,8 @@ describe('Route - Station', () => {
     })
 
     expect(response.statusCode).to.equal(200)
-    expect(response.payload).to.include('<a href="/station/9382">Upstream</a>')
-    expect(response.payload).to.include('<a href="/station/9345">Downstream</a>')
+    expect(response.payload).to.include('href="/station/9382">Upstream</a>')
+    expect(response.payload).to.include('href="/station/9345">Downstream</a>')
   })
 
   it('GET /station/9382/downstream switches from downstream to upstream view within the same multi-reading station', async () => {
@@ -3011,8 +3011,8 @@ describe('Route - Station', () => {
     })
 
     expect(response.statusCode).to.equal(200)
-    expect(response.payload).to.include('<a href="/station/9382">Upstream</a>')
-    expect(response.payload).to.include('<a href="/station/9345">Downstream</a>')
+    expect(response.payload).to.include('href="/station/9382">Upstream</a>')
+    expect(response.payload).to.include('href="/station/9345">Downstream</a>')
   })
 
   it('GET /station/9382 switches from upstream to downstream view within the same multi-reading station', async () => {
@@ -3102,8 +3102,8 @@ describe('Route - Station', () => {
     })
 
     expect(response.statusCode).to.equal(200)
-    expect(response.payload).to.include('<a href="/station/9045">Upstream</a>')
-    expect(response.payload).to.include('<a href="/station/9382/downstream">Downstream</a>')
+    expect(response.payload).to.include('href="/station/9045">Upstream</a>')
+    expect(response.payload).to.include('href="/station/9382/downstream">Downstream</a>')
   })
 
   it('GET /station/9345 navigates correctly to another multi-reading station upstream', async () => {
@@ -3193,8 +3193,8 @@ describe('Route - Station', () => {
     })
 
     expect(response.statusCode).to.equal(200)
-    expect(response.payload).to.include('<a href="/station/9382/downstream">Upstream</a>')
-    expect(response.payload).to.include('<a href="/station/9345/downstream">Downstream</a>')
+    expect(response.payload).to.include('href="/station/9382/downstream">Upstream</a>')
+    expect(response.payload).to.include('href="/station/9345/downstream">Downstream</a>')
   })
 
   it('GET /station/9345/downstream navigates correctly to another multi-reading station', async () => {
@@ -3284,7 +3284,7 @@ describe('Route - Station', () => {
     })
 
     expect(response.statusCode).to.equal(200)
-    expect(response.payload).to.include('<a href="/station/9345">Upstream</a>')
-    expect(response.payload).to.include('<a href="/station/8114">Downstream</a>')
+    expect(response.payload).to.include('href="/station/9345">Upstream</a>')
+    expect(response.payload).to.include('href="/station/8114">Downstream</a>')
   })
 })


### PR DESCRIPTION
* Added GDS classes to the links on the stations page and updated the default class for the `mapButtonClass` on that page.
* Added a class override in _station-links.scss to ensure a visited link remains blue
* Updated tests to ensure changing classes won't affect the core assertions
* Updated rainfall page to also show links as blue text